### PR TITLE
Updated the gridsterItem component to reflect the new min/max item area changes. Fixes #94.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gridster2",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "license": "MIT",
   "main": "dist/index.js",
   "jsnext:main": "dist/index.js",

--- a/src/lib/gridsterItem.component.ts
+++ b/src/lib/gridsterItem.component.ts
@@ -61,7 +61,9 @@ export class GridsterItemComponent implements OnInit, OnDestroy {
       maxItemRows: undefined,
       minItemRows: undefined,
       maxItemCols: undefined,
-      minItemCols: undefined
+      minItemCols: undefined,
+      maxItemArea: undefined,
+      minItemArea: undefined,
     });
   }
 


### PR DESCRIPTION
The `updateOptions()` method which is copying all the properties to the `$item` member is now updated with the two new properties `minItemArea` and `maxItemArea`.