### PR TITLE
[BUGFIX] emptyCellClickCallback not fired when "ignoreContent" is true

### DIFF
--- a/src/lib/gridsterEmptyCell.service.ts
+++ b/src/lib/gridsterEmptyCell.service.ts
@@ -64,7 +64,7 @@ export class GridsterEmptyCell {
   }
 
   emptyCellClickCb(e: any): void {
-    if (this.gridster.movingItem || GridsterUtils.checkContentClassForEvent(this.gridster, e)) {
+    if (this.gridster.movingItem || GridsterUtils.checkContentClassForEmptyCellClickEvent(this.gridster, e)) {
       return;
     }
     const item = this.getValidItemFromEvent(e);
@@ -78,7 +78,7 @@ export class GridsterEmptyCell {
   }
 
   emptyCellContextMenuCb(e: any): void {
-    if (this.gridster.movingItem || GridsterUtils.checkContentClassForEvent(this.gridster, e)) {
+    if (this.gridster.movingItem || GridsterUtils.checkContentClassForEmptyCellClickEvent(this.gridster, e)) {
       return;
     }
     e.preventDefault();
@@ -115,7 +115,7 @@ export class GridsterEmptyCell {
   }
 
   emptyCellMouseDown(e: any): void {
-    if (GridsterUtils.checkContentClassForEvent(this.gridster, e)) {
+    if (GridsterUtils.checkContentClassForEmptyCellClickEvent(this.gridster, e)) {
       return;
     }
     e.preventDefault();

--- a/src/lib/gridsterUtils.service.ts
+++ b/src/lib/gridsterUtils.service.ts
@@ -57,6 +57,14 @@ export class GridsterUtils {
     return false;
   }
 
+  static checkContentClassForEmptyCellClickEvent(gridster: GridsterComponentInterface, e: any): boolean {
+    if (GridsterUtils.checkContentClass(e.target, e.currentTarget, gridster.$options.draggable.ignoreContentClass)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   static checkContentClass(target: any, current: any, contentClass: string): boolean {
     if (target === current) {
       return false;

--- a/src/lib/gridsterUtils.service.ts
+++ b/src/lib/gridsterUtils.service.ts
@@ -58,7 +58,8 @@ export class GridsterUtils {
   }
 
   static checkContentClassForEmptyCellClickEvent(gridster: GridsterComponentInterface, e: any): boolean {
-    if (GridsterUtils.checkContentClass(e.target, e.currentTarget, gridster.$options.draggable.ignoreContentClass)) {
+    if (GridsterUtils.checkContentClass(e.target, e.currentTarget, gridster.$options.draggable.ignoreContentClass
+        || GridsterUtils.checkContentClass(e.target, e.currentTarget, gridster.$options.draggable.dragHandleClass))) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
When "ignoreContent" on draggable is true, the "emptyCellClickCallback" is not fired because it is checked if event target has class "dragHandleClass" - which can never be true for empty cells