### PR TITLE
Fixes #248. Add methods to get the first and last possible position of an item. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ export const GridsterConfigService: GridsterConfig = {
     this.options.api.resize(); // call if size of container changes. Grid will auto resize on window resize.
     this.options.api.optionsChanged(); // call on change of options after initialization
     this.options.api.getNextPossiblePosition(item: GridsterItem); // call to get a viable position for item. Returns true if found
+    this.options.api.getFirstPossiblePosition(item: GridsterItem); // call to get the first viable position for an item. Returns a copy of the item with the future position
+    this.options.api.getLastPossiblePosition(item: GridsterItem); // call to get a viable position for item. Returns a copy of the item with the future position
 
 // if you want to push items from code use the GridsterPush service
 import {GridsterItemComponent, GridsterPush, GridsterPushResize, GridsterSwap} from 'gridster'

--- a/src/lib/gridsterConfig.interface.ts
+++ b/src/lib/gridsterConfig.interface.ts
@@ -90,6 +90,8 @@ export interface GridsterConfig {
     resize?: () => void,
     optionsChanged?: () => void,
     getNextPossiblePosition?: (newItem: GridsterItem) => boolean,
+    getFirstPossiblePosition?: (item: GridsterItem) => GridsterItem,
+    getLastPossiblePosition?: (item: GridsterItem) => GridsterItem,
   };
 
   [propName: string]: any;

--- a/src/lib/gridsterUtils.service.ts
+++ b/src/lib/gridsterUtils.service.ts
@@ -72,4 +72,16 @@ export class GridsterUtils {
       return GridsterUtils.checkContentClass(target.parentNode, current, contentClass);
     }
   }
+
+  static compareItems(item1: { x: number, y: number }, item2: { x: number, y: number }): number {
+      if (item1.y > item2.y) {
+          return -1;
+      } else if (item1.y < item2.y) {
+          return 1;
+      } else if (item1.x > item2.x) {
+          return -1;
+      } else {
+          return 1;
+      }
+  }
 }

--- a/src/lib/tests/gridsterUtils.service.spec.ts
+++ b/src/lib/tests/gridsterUtils.service.spec.ts
@@ -95,3 +95,26 @@ describe('check content class', () => {
     expect(GridsterUtils.checkContentClass(event.target, event.currentTarget, 'body')).toBe(true);
   });
 });
+
+describe('check compare items', () => {
+  it('should return -1, when the first item is further away from origin based on y-value', () => {
+    const firstItem = { x: 2, y: 2 };
+    const secondItem = { x: 1, y: 1 };
+    expect(-1).toBe(GridsterUtils.compareItems(firstItem, secondItem));
+  });
+  it('should return -1, when the first item is further away from origin based on x-value', () => {
+    const firstItem = { x: 2, y: 2 };
+    const secondItem = { x: 1, y: 2 };
+    expect(-1).toBe(GridsterUtils.compareItems(firstItem, secondItem));
+  });
+  it('should return 1, when the second item is further away from origin based on y-value', () => {
+    const firstItem = { x: 1, y: 1 };
+    const secondItem = { x: 2, y: 2 };
+    expect(1).toBe(GridsterUtils.compareItems(firstItem, secondItem));
+  });
+  it('should return 1, when the second item further away from origin based on x-value', () => {
+    const firstItem = { x: 1, y: 2 };
+    const secondItem = { x: 2, y: 2 };
+    expect(1).toBe(GridsterUtils.compareItems(firstItem, secondItem));
+  });
+});


### PR DESCRIPTION
I think this is what the first PR should have looked like: :smile: 

- Fixed the conflict in `README.md`
- Made the PR on the 5.x branch
- Removed the preview of the two methods from the demo app
- The implementation of the methods stayed the same, but I assume they will change a little once you release v5.x of the library.

Let me know if there's anything else!