### PR TITLE
Stop the push algorithm from entering in an infinite loop.

### DIFF
--- a/src/lib/gridsterPush.service.ts
+++ b/src/lib/gridsterPush.service.ts
@@ -50,7 +50,6 @@ export class GridsterPush {
   }
 
   pushItems(direction: string, disable?: boolean): boolean {
-    this.count = 0;
     if (this.gridster.$options.pushItems && !disable) {
       this.pushedItemsOrder = [];
       const pushed = this.push(this.gridsterItem, direction);
@@ -113,11 +112,6 @@ export class GridsterPush {
   }
 
   private push(gridsterItem: GridsterItemComponentInterface, direction: string): boolean {
-    if (this.count > 50000) {
-      return false;
-    } else {
-      this.count++;
-    }
     if (this.gridster.checkGridCollision(gridsterItem.$item)) {
       return false;
     }
@@ -138,7 +132,10 @@ export class GridsterPush {
         makePush = false;
         break;
       }
-      if (this.pushedItemsTemp.indexOf(itemCollision) > -1) {
+      const compare = this.pushedItemsTemp.find((el: GridsterItemComponentInterface) => {
+        return el.$item.x === itemCollision.$item.x && el.$item.y === itemCollision.$item.y;
+      });
+      if (compare) {
         makePush = false;
         break;
       }


### PR DESCRIPTION
Here's how to easily setup the dashboard as in the given example:

```
this.dashboard = [
  ...[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(col => ({ cols: 1, rows: 1, y: 0, x: col })),
  ...[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(col => ({ cols: 1, rows: 1, y: 1, x: col })),
  ...[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(col => ({ cols: 1, rows: 1, y: 2, x: col })),
  { cols: 12, rows: 1, y: 3, x: 0 },
];
```

Also, in the options:
```
minCols: 12,
maxCols: 12,
```

I noticed that you cannot resize the widget more than 2 rows in the north direction. Is this because the other widgets have no place to go?