### PR TITLE
fixed merge function to work with getter/setter props

### DIFF
--- a/src/lib/gridsterUtils.service.ts
+++ b/src/lib/gridsterUtils.service.ts
@@ -7,7 +7,7 @@ export class GridsterUtils {
 
   static merge(obj1: any, obj2: any, properties: any) {
     for (const p in obj2) {
-      if (obj2.hasOwnProperty(p) && properties.hasOwnProperty(p)) {
+     if (obj2[p] !== void 0 && properties.hasOwnProperty(p)) {
         if (typeof obj2[p] === 'object') {
           obj1[p] = GridsterUtils.merge(obj1[p], obj2[p], properties[p]);
         } else {


### PR DESCRIPTION
The current version of the merge function does not determine getter/setter properties. Therefore I check if the given property is not void 0 to check if the obj2 has a field with that given name. The name/functionality for the .hasOwnProperty function sucks in this case.