### PR TITLE
Bug Fix: Update preview on resize event after item deletion

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
@@ -56,7 +56,6 @@ export class GridsterDraggable {
   }
 
   destroy(): void {
-    delete this.gridster.movingItem;
     if (this.gridster.previewStyle) {
       this.gridster.previewStyle(true);
     }

--- a/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
@@ -59,7 +59,6 @@ export class GridsterResizable {
   }
 
   destroy(): void {
-    delete this.gridster.movingItem;
     if (this.gridster.previewStyle) {
       this.gridster.previewStyle();
     }


### PR DESCRIPTION
When a Gridster item was deleted, the global reference to `movingItem` in `GridsterComponent` was deleted. This should not happen, as a resize or drag event could still be in progress. An example case is when an item is deleted in the `GridsterConfig.resizable.start` callback.

This bug only affects resizing and not dragging because `movingItem` is reset in every call of `GridsterDraggable.calculateItemPosition` (called by `dragMove` on every mouse event). `GridsterResizable` never resets `movingItem`, so `GridsterPreviewComponent.previewStyle` stops updating the preview style.

The lines deleted in this PR were introduced in a fix for #199 . I confirmed that that issue was not reintroduced.

[Example on Plunker](https://plnkr.co/edit/MwQnMmpcNuKNKTdq5e61?p=preview)

Addresses Issue #373 