### PR TITLE
Changed grid sizing to work off of the parent element if available.

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.component.ts
+++ b/projects/angular-gridster2/src/lib/gridster.component.ts
@@ -176,17 +176,46 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
   }
 
   setGridSize(): void {
-    let width = this.el.clientWidth;
-    let height = this.el.clientHeight;
-    if (this.$options.setGridSize || this.$options.gridType === 'fit' && !this.mobile) {
-      width = this.el.offsetWidth;
-      height = this.el.offsetHeight;
-    } else {
-      width = this.el.clientWidth;
-      height = this.el.clientHeight;
+    let el = this.el;
+    let widthOffset = 0;
+    let heightOffset = 0;
+
+    if (this.el.parentElement) {
+      const elStyle = document.defaultView.getComputedStyle(this.el);
+      const parentElStyle = document.defaultView.getComputedStyle(this.el.parentElement);
+
+      widthOffset += parseFloat(elStyle.getPropertyValue('margin-left'));
+      widthOffset += parseFloat(elStyle.getPropertyValue('margin-right'));
+      widthOffset += parseFloat(parentElStyle.getPropertyValue('padding-left'));
+      widthOffset += parseFloat(parentElStyle.getPropertyValue('padding-right'));
+
+      if (this.el.clientWidth < this.el.offsetWidth && this.el.scrollHeight > this.el.offsetHeight) {
+        widthOffset += this.el.offsetWidth - this.el.clientWidth;
+      }
+
+      heightOffset += parseFloat(elStyle.getPropertyValue('margin-top'));
+      heightOffset += parseFloat(elStyle.getPropertyValue('margin-bottom'));
+      heightOffset += parseFloat(parentElStyle.getPropertyValue('padding-top'));
+      heightOffset += parseFloat(parentElStyle.getPropertyValue('padding-bottom'));
+
+      if (this.el.clientHeight < this.el.offsetHeight && this.el.scrollWidth > this.el.offsetWidth) {
+        heightOffset += this.el.offsetHeight - this.el.clientHeight;
+      }
+
+      el = this.el.parentElement;
     }
-    this.curWidth = width;
-    this.curHeight = height;
+
+    let width = el.clientWidth;
+    let height = el.clientHeight;
+    if (this.$options.setGridSize || this.$options.gridType === 'fit' && !this.mobile) {
+      width = el.offsetWidth;
+      height = el.offsetHeight;
+    } else {
+      width = el.clientWidth;
+      height = el.clientHeight;
+    }
+    this.curWidth = width - widthOffset;
+    this.curHeight = height - heightOffset;
   }
 
   setGridDimensions(): void {


### PR DESCRIPTION
When using the "verticalFixed" mode and "setGridSize" I noticed that the grid would shrink properly as the parent container shrunk, but would not grow with the parent container.

I attempted to account for margins on the gridster element and padding on the parent element in the resizing as well as the vertical and horizontal scroll bars on the gridster element.