### PR TITLE
Fix blurry text inside cells

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
@@ -229,8 +229,8 @@ export class GridsterDraggable {
     if (this.gridster.checkGridCollision(this.gridsterItem.$item)) {
       this.gridsterItem.$item.y = this.positionYBackup;
     }
-    const transform = 'translate(' + this.left + 'px, ' + this.top + 'px)';
-    this.gridsterItem.renderer.setStyle(this.gridsterItem.el, 'transform', transform);
+    this.gridsterItem.renderer.setStyle(this.gridsterItem.el, 'top', this.top + 'px');
+    this.gridsterItem.renderer.setStyle(this.gridsterItem.el, 'left', this.left + 'px');
 
     if (this.positionXBackup !== this.gridsterItem.$item.x || this.positionYBackup !== this.gridsterItem.$item.y) {
       const lastPosition = this.path[this.path.length - 1];

--- a/projects/angular-gridster2/src/lib/gridsterRenderer.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterRenderer.service.ts
@@ -16,7 +16,8 @@ export class GridsterRenderer {
 
   updateItem(el: any, item: GridsterItem, renderer: Renderer2) {
     if (this.gridster.mobile) {
-      renderer.setStyle(el, 'transform', '');
+      renderer.setStyle(el, 'top', '');
+      renderer.setStyle(el, 'left', '');
       if (this.gridster.$options.keepFixedHeightInMobile) {
         renderer.setStyle(el, 'height', (item.rows * this.gridster.$options.fixedRowHeight) + 'px');
       } else {
@@ -35,8 +36,9 @@ export class GridsterRenderer {
       const y = Math.round(this.gridster.curRowHeight * item.y);
       const width = this.gridster.curColWidth * item.cols - this.gridster.$options.margin;
       const height = (this.gridster.curRowHeight * item.rows - this.gridster.$options.margin);
-      const transform = 'translate3d(' + x + 'px, ' + y + 'px, 0)';
-      renderer.setStyle(el, 'transform', transform);
+      // set the cell style
+      renderer.setStyle(el, 'left', this.gridster.$options.margin + x + 'px');
+      renderer.setStyle(el, 'top', this.gridster.$options.margin + y + 'px');
       renderer.setStyle(el, 'width', width + 'px');
       renderer.setStyle(el, 'height', height + 'px');
       let marginBottom: string | null = null;
@@ -122,7 +124,7 @@ export class GridsterRenderer {
 
   getGridColumnStyle(i: number) {
     return {
-      transform: 'translateX(' + this.gridster.curColWidth * i + 'px)',
+      left: this.gridster.$options.margin + this.gridster.curColWidth * i + 'px',
       width: this.gridster.curColWidth - this.gridster.$options.margin + 'px',
       height: this.gridster.gridRows.length * this.gridster.curRowHeight - this.gridster.$options.margin + 'px'
     };
@@ -130,7 +132,7 @@ export class GridsterRenderer {
 
   getGridRowStyle(i: number) {
     return {
-      transform: 'translateY(' + this.gridster.curRowHeight * i + 'px)',
+      top: this.gridster.$options.margin + this.gridster.curRowHeight * i + 'px',
       width: this.gridster.gridColumns.length * this.gridster.curColWidth - this.gridster.$options.margin + 'px',
       height: this.gridster.curRowHeight - this.gridster.$options.margin + 'px'
     };

--- a/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
@@ -394,13 +394,11 @@ export class GridsterResizable {
   }
 
   setItemTop(top: number): void {
-    const transform = 'translate(' + this.left + 'px, ' + top + 'px)';
-    this.gridsterItem.renderer.setStyle(this.gridsterItem.el, 'transform', transform);
+    this.gridsterItem.renderer.setStyle(this.gridsterItem.el, 'top', top + 'px');
   }
 
   setItemLeft(left: number): void {
-    const transform = 'translate(' + left + 'px, ' + this.top + 'px)';
-    this.gridsterItem.renderer.setStyle(this.gridsterItem.el, 'transform', transform);
+    this.gridsterItem.renderer.setStyle(this.gridsterItem.el, 'left', left + 'px');
   }
 
   setItemHeight(height: number): void {


### PR DESCRIPTION
Chrome has a lot of problems with blurry text when parent has a `translate3d` property.
There are a lot of posts about that but all the solutions found didn't work for me.

With this PR I'm rolling back the use of `translate3d` to the old but gold `left` and `top` properties.

Fix #377 