### PR TITLE
Fix issue #441

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterEmptyCell.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterEmptyCell.service.ts
@@ -143,7 +143,8 @@ export class GridsterEmptyCell {
     e.preventDefault();
     e.stopPropagation();
     const item = this.getValidItemFromEvent(e);
-    if (!item) {
+    const leftMouseButtonCode = 1;
+    if (!item || e.buttons !== leftMouseButtonCode) {
       return;
     }
     this.initialItem = item;


### PR DESCRIPTION
This change is to prevent dragging from an empty cell using a mouse button other than the left, as allowing more than one button to be pressed during the dragging causes the grid to behave in unpredictable ways, like creating multiple items (the extra items on the topmost and leftmost cell) or misaliging them.

https://github.com/tiberiuzuld/angular-gridster2/issues/441