### PR TITLE
Check this.options is set before using it

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.component.ts
+++ b/projects/angular-gridster2/src/lib/gridster.component.ts
@@ -138,10 +138,10 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
     if (this.windowResize) {
       this.windowResize();
     }
-    if (this.options.destroyCallback) {
+    if (this.options && this.options.destroyCallback) {
       this.options.destroyCallback(this);
     }
-    if (this.options.api) {
+    if (this.options && this.options.api) {
       this.options.api.resize = undefined;
       this.options.api.optionsChanged = undefined;
       this.options.api.getNextPossiblePosition = undefined;


### PR DESCRIPTION
Quickly navigating away from a page that has the angular-gridster2 component would cause the error: Cannot read 'destroyCallback' of undefined to be thrown.