### PR TITLE
New option to allow "empty cell" drops even on occupied spaces

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
@@ -52,6 +52,7 @@ export const GridsterConfigService: GridsterConfig = {
   enableEmptyCellContextMenu: false, // enable empty cell context menu (right click) events
   enableEmptyCellDrop: false, // enable empty cell drop events
   enableEmptyCellDrag: false, // enable empty cell drag events
+  enableOccupiedCellDrop: false, // enable occupied cell drop events
   emptyCellClickCallback: undefined, // empty cell click callback
   emptyCellContextMenuCallback: undefined, // empty cell context menu (right click) callback
   emptyCellDropCallback: undefined, // empty cell drag drop callback. HTML5 Drag & Drop

--- a/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
@@ -97,6 +97,7 @@ export interface GridsterConfig {
   enableEmptyCellContextMenu?: boolean;
   enableEmptyCellDrop?: boolean;
   enableEmptyCellDrag?: boolean;
+  enableOccupiedCellDrop?: boolean;
   emptyCellClickCallback?: (event: MouseEvent, item: GridsterItem) => void;
   emptyCellContextMenuCallback?: (event: MouseEvent, item: GridsterItem) => void;
   emptyCellDropCallback?: (event: MouseEvent, item: GridsterItem) => void;

--- a/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
@@ -51,6 +51,7 @@ export interface GridsterConfigS {
   enableEmptyCellContextMenu: boolean;
   enableEmptyCellDrop: boolean;
   enableEmptyCellDrag: boolean;
+  enableOccupiedCellDrop: boolean;
   emptyCellDragMaxCols: number;
   emptyCellDragMaxRows: number;
   ignoreMarginInRow: boolean;

--- a/projects/angular-gridster2/src/lib/gridsterEmptyCell.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterEmptyCell.service.ts
@@ -219,7 +219,7 @@ export class GridsterEmptyCell {
         item.y = this.gridster.movingItem ? this.gridster.movingItem.y : 0;
       }
     }
-    if (this.gridster.checkCollision(item)) {
+    if (!this.gridster.$options.enableOccupiedCellDrop && this.gridster.checkCollision(item)) {
       return;
     }
     return item;

--- a/src/app/sections/emptyCell/emptyCell.component.html
+++ b/src/app/sections/emptyCell/emptyCell.component.html
@@ -17,6 +17,9 @@
     Enable drop to add
   </mat-checkbox>
   <div *ngIf="options.enableEmptyCellDrop" draggable="true" (dragstart)="dragStartHandler($event)">Drag me!</div>
+  <mat-checkbox [(ngModel)]="options.enableOccupiedCellDrop" (ngModelChange)="changedOptions()" [disabled]="!options.enableEmptyCellDrop">
+    Enable drop on occupied cell
+  </mat-checkbox>
   <mat-checkbox [(ngModel)]="options.enableEmptyCellDrag" (ngModelChange)="changedOptions()">
     Enable drag to add
   </mat-checkbox>

--- a/src/app/sections/emptyCell/emptyCell.component.ts
+++ b/src/app/sections/emptyCell/emptyCell.component.ts
@@ -20,6 +20,7 @@ export class EmptyCellComponent implements OnInit {
       enableEmptyCellContextMenu: false,
       enableEmptyCellDrop: false,
       enableEmptyCellDrag: false,
+      enableOccupiedCellDrop: false,
       emptyCellClickCallback: this.emptyCellClick.bind(this),
       emptyCellContextMenuCallback: this.emptyCellClick.bind(this),
       emptyCellDropCallback: this.emptyCellClick.bind(this),

--- a/src/app/sections/home/home.component.ts
+++ b/src/app/sections/home/home.component.ts
@@ -46,6 +46,7 @@ export class HomeComponent implements OnInit {
       enableEmptyCellContextMenu: false,
       enableEmptyCellDrop: false,
       enableEmptyCellDrag: false,
+      enableOccupiedCellDrop: false,
       emptyCellDragMaxCols: 50,
       emptyCellDragMaxRows: 50,
       ignoreMarginInRow: false,

--- a/src/assets/emptyCell.md
+++ b/src/assets/emptyCell.md
@@ -6,6 +6,7 @@ enableEmptyCellClick | enable empty cell click events | Boolean | false
 enableEmptyCellContextMenu | enable empty cell context menu (right click) events | Boolean | false
 enableEmptyCellDrop | enable empty cell drop events | Boolean | false
 enableEmptyCellDrag | enable empty cell drag events | Boolean | false
+enableOccupiedCellDrop | enable occupied cell drop events | Boolean | false
 emptyCellDragMaxCols | limit empty cell drag max cols | Number | 50
 emptyCellDragMaxRows | limit empty cell drag max rows | Number | 50
 emptyCellClickCallback | empty cell click callback | Function(event, gridsterItem) | undefined


### PR DESCRIPTION
The Gridster component will accept a drop from outside the container, even on occupied spaces. When a new item is dropped on an occupied space, it is automatically bumped to the next available space.