### PR TITLE
swap while Dragging implemented. 

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
@@ -91,6 +91,7 @@ export const GridsterConfigService: GridsterConfig = {
     // Arguments: item, gridsterItem, event
   },
   swap: true, // allow items to switch position if drop on top of another
+  swapWhileDragging: true, // allow items to switch position while dragging
   pushItems: false, // push items when resizing and dragging
   disablePushOnDrag: false, // disable push on drag
   disablePushOnResize: false, // disable push on resize

--- a/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
@@ -81,6 +81,7 @@ export interface GridsterConfig {
   draggable?: Draggable;
   resizable?: Resizable;
   swap?: boolean;
+  swapWhileDragging?: boolean;
   pushItems?: boolean;
   disablePushOnDrag?: boolean;
   disablePushOnResize?: boolean;

--- a/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
@@ -35,6 +35,7 @@ export interface GridsterConfigS {
   draggable: Draggable;
   resizable: Resizable;
   swap: boolean;
+  swapWhileDragging: boolean;
   pushItems: boolean;
   disablePushOnDrag: boolean;
   disablePushOnResize: boolean;

--- a/projects/angular-gridster2/src/lib/gridsterSwap.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterSwap.service.ts
@@ -82,6 +82,10 @@ export class GridsterSwap {
       } else {
         gridsterItemCollide.setSize();
         this.swapedItem = gridsterItemCollide;
+        if (this.gridster.$options.swapWhileDragging) {
+          this.gridsterItem.checkItemChanges(this.gridsterItem.$item, this.gridsterItem.item);
+          this.setSwapItem();
+        }
       }
     }
   }


### PR DESCRIPTION
When swap has been made, we check thee changes for the gridster Item and set the swaped item.

Before this pull request (only swap)

![currentSwap](https://user-images.githubusercontent.com/34038087/63274817-c2301e00-c2a0-11e9-8613-18e9428686b8.gif)

After this pull request (swap and swapWhileDragging . both enabled)

![swapWhileDragging](https://user-images.githubusercontent.com/34038087/63274885-de33bf80-c2a0-11e9-89ab-985f3f0668c6.gif)

Hope you like it ;)
