### PR TITLE
swap boundaries implemented in swapWhileDragging . 

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.component.ts
+++ b/projects/angular-gridster2/src/lib/gridster.component.ts
@@ -357,6 +357,7 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
     return collision;
   }
 
+
   checkGridCollision(item: GridsterItem): boolean {
     const noNegativePosition = item.y > -1 && item.x > -1;
     const maxGridCols = item.cols + item.x <= this.$options.maxCols;
@@ -386,6 +387,7 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
     return false;
   }
 
+
   findItemsWithItem(item: GridsterItem): Array<GridsterItemComponentInterface> {
     const a: Array<GridsterItemComponentInterface> = [];
     let widgetsIndex: number = this.grid.length - 1, widget: GridsterItemComponentInterface;
@@ -397,6 +399,8 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
     }
     return a;
   }
+
+
 
   autoPositionItem(itemComponent: GridsterItemComponentInterface): void {
     if (this.getNextPossiblePosition(itemComponent.$item)) {
@@ -494,4 +498,52 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
   positionYToPixels(y: number): number {
     return y * this.curRowHeight;
   }
+
+  // ------ Functions for swapWhileDragging option
+
+  // identical to checkCollision() except that here we add bondaries. 
+  static checkCollisionTwoItemsForSwaping(item: GridsterItem, item2: GridsterItem): boolean {
+    // if the cols or rows of the items are 1 , doesnt make any sense to set a boundary. Only if the item is bigger we set a boundary
+    const horizontalBoundaryItem1 = item.cols === 1 ? 0 : 1;
+    const horizontalBoundaryItem2 = item2.cols === 1 ? 0 : 1;
+    const verticalBoundaryItem1 = item.rows === 1 ? 0 : 1;
+    const verticalBoundaryItem2 = item2.rows === 1 ? 0 : 1;
+    return item.x + horizontalBoundaryItem1 < item2.x + item2.cols
+      && item.x + item.cols > item2.x + horizontalBoundaryItem2
+      && item.y + verticalBoundaryItem1 < item2.y + item2.rows
+      && item.y + item.rows > item2.y + verticalBoundaryItem2;
+  }
+
+  // identical to checkCollision() except that this function calls findItemWithItemForSwaping() instead of findItemWithItem()
+  checkCollisionForSwaping(item: GridsterItem): GridsterItemComponentInterface | boolean {
+    let collision: GridsterItemComponentInterface | boolean = false;
+    if (this.options.itemValidateCallback) {
+      collision = !this.options.itemValidateCallback(item);
+    }
+    if (!collision && this.checkGridCollision(item)) {
+      collision = true;
+    }
+    if (!collision) {
+      const c = this.findItemWithItemForSwaping(item);
+      if (c) {
+        collision = c;
+      }
+    }
+    return collision;
+  }
+
+  // identical to findItemWithItem() except that this function calls checkCollisionTwoItemsForSwaping() instead of checkCollisionTwoItems()
+  findItemWithItemForSwaping(item: GridsterItem): GridsterItemComponentInterface | boolean {
+    let widgetsIndex: number = this.grid.length - 1, widget: GridsterItemComponentInterface;
+    for (; widgetsIndex > -1; widgetsIndex--) {
+      widget = this.grid[widgetsIndex];
+      if (widget.$item !== item && GridsterComponent.checkCollisionTwoItemsForSwaping(widget.$item, item)) {
+        return widget;
+      }
+    }
+    return false;
+  }
+
+  // ------ End of functions for swapWhileDragging option
+
 }

--- a/projects/angular-gridster2/src/lib/gridster.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridster.interface.ts
@@ -11,6 +11,7 @@ export abstract class GridsterComponentInterface {
   $options: GridsterConfigS;
   grid: Array<GridsterItemComponentInterface>;
   checkCollision: (item: GridsterItem) => GridsterItemComponentInterface | boolean;
+  checkCollisionForSwaping: (item: GridsterItem) => GridsterItemComponentInterface | boolean;
   positionXToPixels: (x: number) => number;
   pixelsToPositionX: (x: number, roundingMethod: (x: number) => number, noLimit?: boolean) => number;
   positionYToPixels: (y: number) => number;

--- a/projects/angular-gridster2/src/lib/gridsterSwap.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterSwap.service.ts
@@ -63,7 +63,12 @@ export class GridsterSwap {
   }
 
   checkSwap(pushedBy: GridsterItemComponentInterface): void {
-    const gridsterItemCollision: any = this.gridster.checkCollision(pushedBy.$item);
+    let gridsterItemCollision;
+    if (this.gridster.$options.swapWhileDragging) {
+      gridsterItemCollision = this.gridster.checkCollisionForSwaping(pushedBy.$item);
+    }else{
+      gridsterItemCollision = this.gridster.checkCollision(pushedBy.$item);
+    }
     if (gridsterItemCollision && gridsterItemCollision !== true && gridsterItemCollision.canBeDragged()) {
       const gridsterItemCollide: GridsterItemComponentInterface = gridsterItemCollision;
       const copyCollisionX = gridsterItemCollide.$item.x;


### PR DESCRIPTION
Fix to the swap boundary problem.

So in the swapWhileDragging feature there was a problem when the grid was fixed, the height and width of the grid were 60 each and the user tried to swap very slowly. 

Example : 

![currentBoundaryProblem](https://user-images.githubusercontent.com/34038087/63857663-68b4a700-c9a4-11e9-9a1a-044a1a3fa7b5.gif)

The problem was happening because the checkSwap() is called a lot , so when the user swap very slowly this lag appears. It is only appearing in the swapWhileDragging because the function setSwapItem() in the swapService is been called. After checking how the checkCollision works , I came to the idea of setting some boundaries to decide when to swap. The current behaviour swaps as soon as a small collision appears, in this pull request I expect to be a bigger collision to actually swap the items, I think this boundaries should be applied to the regular swap behaviour as well, but I did it only for the swapWhileDragging option. Maybe you should consider to apply this boundaries to the regular swap behaviour (but thats another story, for now only in the swapWhileDragging option)

After this pull request (boundaries to swap set)

![boundaryProblemFixed](https://user-images.githubusercontent.com/34038087/63858369-a36b0f00-c9a5-11e9-8f42-32955c281d8b.gif)

I hope it is clear enough what and why I did this. Any questions or suggestions are welcome. 



