### PR TITLE
Ivy Compatibility

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.component.ts
+++ b/projects/angular-gridster2/src/lib/gridster.component.ts
@@ -9,7 +9,8 @@ import {
   OnInit,
   Renderer2,
   SimpleChanges,
-  ViewEncapsulation
+  ViewEncapsulation,
+  Inject
 } from '@angular/core';
 
 import {GridsterConfigService} from './gridsterConfig.constant';
@@ -52,7 +53,7 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
   compact: GridsterCompact;
   gridRenderer: GridsterRenderer;
 
-  constructor(el: ElementRef, public renderer: Renderer2, public cdRef: ChangeDetectorRef, public zone: NgZone) {
+  constructor(@Inject(ElementRef) el: ElementRef, @Inject(Renderer2) public renderer: Renderer2, @Inject(ChangeDetectorRef) public cdRef: ChangeDetectorRef, @Inject(NgZone) public zone: NgZone) {
     this.el = el.nativeElement;
     this.$options = JSON.parse(JSON.stringify(GridsterConfigService));
     this.calculateLayoutDebounce = GridsterUtils.debounce(this.calculateLayout.bind(this), 0);

--- a/projects/angular-gridster2/src/lib/gridsterItem.component.ts
+++ b/projects/angular-gridster2/src/lib/gridsterItem.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, Host, Input, NgZone, OnDestroy, OnInit, Renderer2, ViewEncapsulation} from '@angular/core';
+import {Component, ElementRef, Host, Input, NgZone, OnDestroy, OnInit, Renderer2, ViewEncapsulation, Inject} from '@angular/core';
 
 import {GridsterItem} from './gridsterItem.interface';
 import {GridsterDraggable} from './gridsterDraggable.service';
@@ -27,7 +27,7 @@ export class GridsterItemComponent implements OnInit, OnDestroy, GridsterItemCom
   notPlaced: boolean;
   init: boolean;
 
-  constructor(el: ElementRef, @Host() gridster: GridsterComponent, public renderer: Renderer2, private zone: NgZone) {
+  constructor(@Inject(ElementRef) el: ElementRef,  gridster: GridsterComponent, @Inject(Renderer2) public renderer: Renderer2, @Inject(NgZone) private zone: NgZone) {
     this.el = el.nativeElement;
     this.$item = {
       cols: -1,

--- a/projects/angular-gridster2/src/lib/gridsterPreview.component.ts
+++ b/projects/angular-gridster2/src/lib/gridsterPreview.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, Host, OnDestroy, Renderer2, ViewEncapsulation} from '@angular/core';
+import {Component, ElementRef, Host, OnDestroy, Renderer2, ViewEncapsulation, Inject} from '@angular/core';
 
 import {GridsterComponent} from './gridster.component';
 
@@ -12,7 +12,7 @@ export class GridsterPreviewComponent implements OnDestroy {
   el: any;
   gridster: GridsterComponent;
 
-  constructor(el: ElementRef, @Host() gridster: GridsterComponent, public renderer: Renderer2) {
+  constructor(@Inject(ElementRef)  el: ElementRef,  gridster: GridsterComponent, @Inject(Renderer2) public renderer: Renderer2) {
     this.el = el.nativeElement;
     this.gridster = gridster;
     this.gridster.previewStyle = this.previewStyle.bind(this);


### PR DESCRIPTION
**Description**

Due to the [this known breaking change](https://docs.google.com/document/d/1Dije0AsJ0PxL3NaeNPxpYDeapj30b_QC0xfeIvIIzgg/preview) related to `@Host()` decorator in Ivy, Ivy enabled applications were throwing this error:

`Error: NodeInjector: NOT_FOUND [GridsterComponent]
    at getOrCreateInjectable (core.js:5673) [angular]
    at Module.ɵɵdirectiveInject (core.js:20853) [angular]
    at NodeInjectorFactory.GridsterItemComponent_Factory [as factory] (angular-gridster2.js:4587) [angular]
    at getNodeInjectable (core.js:5806) [angular]
    at instantiateRootComponent (core.js:12779) [angular]
    at createRootComponent (core.js:24658) [angular]
    at ComponentFactory$1.create (core.js:32531) [angular]
    at DowngradeComponentAdapter.createComponent (static.js:302) [angular]
    at doDowngrade (static.js:703) [angular]
    at :3000/vendor.js:142647:55 [angular]
    at SyncPromise.then (static.js:558) [angular]
    at Object.link (static.js:725) [angular]
    at :3000/vendor.js:259266:18 [angular]`

**Resolution**

**Note: This may be a breaking change**
Change element injection signature in the constructors that had the `@Host()` decorator by removing it and using the `@Inject()` decorator to inject elementRef et al. This seems to resolve the issue and gridster components works as expected.

**Before this PR:**

![image](https://user-images.githubusercontent.com/13848977/63988714-c0761e00-cb1c-11e9-9dc0-da61305eafc6.png)

**After this PR:**

Using angular-gridster2 components in Ivy enabled app successfully

![image](https://user-images.githubusercontent.com/13848977/63235926-e5e06d80-c27a-11e9-8a9c-cc6ed54fed1c.png)
