### PR TITLE
Changed gridster-item resize handle cursor

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterItem.css
+++ b/projects/angular-gridster2/src/lib/gridsterItem.css
@@ -25,7 +25,7 @@ gridster-item.gridster-item-resizing, gridster-item.gridster-item-moving {
 }
 
 .gridster-item-resizable-handler.handle-n {
-  cursor: n-resize;
+  cursor: ns-resize;
   height: 10px;
   right: 0;
   top: 0;
@@ -33,7 +33,7 @@ gridster-item.gridster-item-resizing, gridster-item.gridster-item-moving {
 }
 
 .gridster-item-resizable-handler.handle-e {
-  cursor: e-resize;
+  cursor: ew-resize;
   width: 10px;
   bottom: 0;
   right: 0;
@@ -41,7 +41,7 @@ gridster-item.gridster-item-resizing, gridster-item.gridster-item-moving {
 }
 
 .gridster-item-resizable-handler.handle-s {
-  cursor: s-resize;
+  cursor: ns-resize;
   height: 10px;
   right: 0;
   bottom: 0;
@@ -49,7 +49,7 @@ gridster-item.gridster-item-resizing, gridster-item.gridster-item-moving {
 }
 
 .gridster-item-resizable-handler.handle-w {
-  cursor: w-resize;
+  cursor: ew-resize;
   width: 10px;
   left: 0;
   top: 0;


### PR DESCRIPTION
Up until now with my experience with Angular Gridster2 I think using the cursor "ns-resize" for handle-n as well as handle-s and using the "ew-resize" cursor for handle-w and handle-e will be better than the previous css. The reason for this is the gridster-item can be resized in both directions, so both directions should be indicated with the cursor. Another reason is that these icons are more familiar for most people for resizing elements in applications.