### PR TITLE
Don't start drag on non-LMB press event

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
@@ -70,14 +70,8 @@ export class GridsterDraggable {
   }
 
   dragStart(e: any): void {
-    switch (e.which) {
-      case 1:
-        // left mouse button
-        break;
-      case 2:
-      case 3:
-        // right or middle mouse button
-        return;
+    if (e.which !== 1) {
+      return;
     }
 
     if (this.gridster.options.draggable && this.gridster.options.draggable.start) {


### PR DESCRIPTION
When user has mouse with more than 3 buttons, he can drag items with button 4 and 5, which is annoying and may prevent user from leaving page (these buttons is used for browser history navigation).

This simple PR disables drag completely for non-LMB press events.