### PR TITLE
Rtl support

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
@@ -104,5 +104,6 @@ export const GridsterConfigService: GridsterConfig = {
   scrollToNewItems: false, // scroll to new items placed in a scrollable view
   disableScrollHorizontal: false, // disable horizontal scrolling
   disableScrollVertical: false, // disable vertical scrolling
-  disableAutoPositionOnConflict: false  // disable auto-position of items on conflict state
+  disableAutoPositionOnConflict: false,  // disable auto-position of items on conflict state,
+  dir: "ltr"
 };

--- a/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
@@ -105,5 +105,5 @@ export const GridsterConfigService: GridsterConfig = {
   disableScrollHorizontal: false, // disable horizontal scrolling
   disableScrollVertical: false, // disable vertical scrolling
   disableAutoPositionOnConflict: false,  // disable auto-position of items on conflict state,
-  dir: "ltr"
+  dirType: "ltr"
 };

--- a/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
@@ -105,5 +105,5 @@ export const GridsterConfigService: GridsterConfig = {
   disableScrollHorizontal: false, // disable horizontal scrolling
   disableScrollVertical: false, // disable vertical scrolling
   disableAutoPositionOnConflict: false,  // disable auto-position of items on conflict state,
-  dirType: "ltr"
+  dirType: "ltr",//page direction, rtl=right to left ltr= left to right, if you use rtl language set dirType to rtl
 };

--- a/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
@@ -40,7 +40,7 @@ export enum CompactType {
   CompactRightAndUp = 'compactRight&Up',
 }
 
-export type dir = 'ltr' | 'rtl';
+export type dirTypes = 'ltr' | 'rtl';
 
 export interface GridsterConfig {
   gridType?: gridTypes;
@@ -118,7 +118,7 @@ export interface GridsterConfig {
 
   [propName: string]: any;
 
-  dir: dir;
+  dirType?: dirTypes;
 }
 
 export interface DragBase {

--- a/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
@@ -40,6 +40,8 @@ export enum CompactType {
   CompactRightAndUp = 'compactRight&Up',
 }
 
+export type dir = 'ltr' | 'rtl';
+
 export interface GridsterConfig {
   gridType?: gridTypes;
   fixedColWidth?: number;
@@ -115,6 +117,8 @@ export interface GridsterConfig {
   };
 
   [propName: string]: any;
+
+  dir: dir;
 }
 
 export interface DragBase {

--- a/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
@@ -1,6 +1,6 @@
-import {compactTypes, displayGrids, gridTypes, dir} from './gridsterConfig.interface';
 import {GridsterItem} from './gridsterItem.interface';
 import {GridsterComponentInterface} from './gridster.interface';
+import { compactTypes, displayGrids, gridTypes, dirTypes } from './gridsterConfig.interface';
 
 export interface GridsterConfigS {
   gridType: gridTypes;
@@ -65,7 +65,7 @@ export interface GridsterConfigS {
   };
 
   [propName: string]: any;
-  dir:dir;
+  dirType: dirTypes;
 }
 
 export interface DragBase {

--- a/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
@@ -1,4 +1,4 @@
-import {compactTypes, displayGrids, gridTypes} from './gridsterConfig.interface';
+import {compactTypes, displayGrids, gridTypes, dir} from './gridsterConfig.interface';
 import {GridsterItem} from './gridsterItem.interface';
 import {GridsterComponentInterface} from './gridster.interface';
 
@@ -65,6 +65,7 @@ export interface GridsterConfigS {
   };
 
   [propName: string]: any;
+  dir:dir;
 }
 
 export interface DragBase {

--- a/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
@@ -106,7 +106,11 @@ export class GridsterDraggable {
     this.top = this.gridsterItem.top - this.margin;
     this.width = this.gridsterItem.width;
     this.height = this.gridsterItem.height;
-    this.diffLeft = e.clientX + this.offsetLeft - this.margin - this.left;
+    if (this.gridster.$options.dirType === "rtl") {
+      this.diffLeft = (e.clientX - this.gridster.el.scrollWidth + this.gridsterItem.left);
+    } else {
+      this.diffLeft = e.clientX + this.offsetLeft - this.margin - this.left;
+    }
     this.diffTop = e.clientY + this.offsetTop - this.margin - this.top;
     this.gridster.movingItem = this.gridsterItem.$item;
     this.gridster.previewStyle(true);
@@ -130,7 +134,12 @@ export class GridsterDraggable {
   }
 
   calculateItemPositionFromMousePosition(e: any): void {
-    this.left = e.clientX + this.offsetLeft - this.diffLeft;
+    if (this.gridster.$options.dirType === "rtl") {
+      this.left = this.gridster.el.scrollWidth - e.clientX + this.diffLeft;
+    } else {
+      this.left = e.clientX + this.offsetLeft - this.diffLeft;
+    }
+
     this.top = e.clientY + this.offsetTop - this.diffTop;
     this.calculateItemPosition();
     this.lastMouse.clientX = e.clientX;

--- a/projects/angular-gridster2/src/lib/gridsterRenderer.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterRenderer.service.ts
@@ -137,7 +137,7 @@ export class GridsterRenderer {
   }
 
   getLeftPosition(d: number): Object {
-    if (this.gridster.$options.dir === "rtl") {
+    if (this.gridster.$options.dirType === "rtl") {
       if (this.gridster.$options.useTransformPositioning) {
         return {
           transform: 'translateX(' + (-d) + 'px)',
@@ -182,7 +182,7 @@ export class GridsterRenderer {
   }
 
   setCellPosition(renderer: Renderer2, el: any, x: number, y: number): void {
-    if (this.gridster.$options.dir === "rtl") {
+    if (this.gridster.$options.dirType === "rtl") {
       if (this.gridster.$options.useTransformPositioning) {
         const transform = 'translate3d(' + (- x) + 'px, ' + y + 'px, 0)';
         renderer.setStyle(el, 'transform', transform);

--- a/projects/angular-gridster2/src/lib/gridsterRenderer.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterRenderer.service.ts
@@ -1,8 +1,8 @@
-import {Injectable, Renderer2} from '@angular/core';
+import { Injectable, Renderer2 } from '@angular/core';
 
-import {GridsterComponentInterface} from './gridster.interface';
-import {GridType} from './gridsterConfig.interface';
-import {GridsterItem} from './gridsterItem.interface';
+import { GridsterComponentInterface } from './gridster.interface';
+import { GridType } from './gridsterConfig.interface';
+import { GridsterItem } from './gridsterItem.interface';
 
 @Injectable()
 export class GridsterRenderer {
@@ -20,7 +20,7 @@ export class GridsterRenderer {
       if (this.gridster.$options.keepFixedHeightInMobile) {
         renderer.setStyle(el, 'height', (item.rows * this.gridster.$options.fixedRowHeight) + 'px');
       } else {
-        renderer.setStyle(el, 'height',  (item.rows * this.gridster.curWidth / item.cols ) + 'px');
+        renderer.setStyle(el, 'height', (item.rows * this.gridster.curWidth / item.cols) + 'px');
       }
       if (this.gridster.$options.keepFixedWidthInMobile) {
         renderer.setStyle(el, 'width', this.gridster.$options.fixedColWidth + 'px');
@@ -137,14 +137,26 @@ export class GridsterRenderer {
   }
 
   getLeftPosition(d: number): Object {
-    if (this.gridster.$options.useTransformPositioning) {
-      return {
-        transform: 'translateX(' + d + 'px)',
-      };
+    if (this.gridster.$options.dir === "rtl") {
+      if (this.gridster.$options.useTransformPositioning) {
+        return {
+          transform: 'translateX(' + (-d) + 'px)',
+        };
+      } else {
+        return {
+          left: -(this.getLeftMargin() + d) + 'px'
+        };
+      }
     } else {
-      return {
-        left: (this.getLeftMargin() + d) + 'px'
-      };
+      if (this.gridster.$options.useTransformPositioning) {
+        return {
+          transform: 'translateX(' + d + 'px)',
+        };
+      } else {
+        return {
+          left: (this.getLeftMargin() + d) + 'px'
+        };
+      }
     }
   }
 
@@ -170,12 +182,22 @@ export class GridsterRenderer {
   }
 
   setCellPosition(renderer: Renderer2, el: any, x: number, y: number): void {
-    if (this.gridster.$options.useTransformPositioning) {
-      const transform = 'translate3d(' + x + 'px, ' + y + 'px, 0)';
-      renderer.setStyle(el, 'transform', transform);
+    if (this.gridster.$options.dir === "rtl") {
+      if (this.gridster.$options.useTransformPositioning) {
+        const transform = 'translate3d(' + (- x) + 'px, ' + y + 'px, 0)';
+        renderer.setStyle(el, 'transform', transform);
+      } else {
+        renderer.setStyle(el, 'left', -(this.getLeftMargin() + x) + 'px');
+        renderer.setStyle(el, 'top', this.getTopMargin() + y + 'px');
+      }
     } else {
-      renderer.setStyle(el, 'left', this.getLeftMargin() + x + 'px');
-      renderer.setStyle(el, 'top', this.getTopMargin() + y + 'px');
+      if (this.gridster.$options.useTransformPositioning) {
+        const transform = 'translate3d(' + x + 'px, ' + y + 'px, 0)';
+        renderer.setStyle(el, 'transform', transform);
+      } else {
+        renderer.setStyle(el, 'left', this.getLeftMargin() + x + 'px');
+        renderer.setStyle(el, 'top', this.getTopMargin() + y + 'px');
+      }
     }
   }
 

--- a/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
@@ -125,30 +125,64 @@ export class GridsterResizable {
       this.resizeEventScrollType.n = true;
       this.directionFunction = this.handleN;
     } else if (e.target.hasAttribute('class') && e.target.getAttribute('class').split(' ').indexOf('handle-w') > -1) {
-      this.resizeEventScrollType.w = true;
-      this.directionFunction = this.handleW;
+      if (this.gridster.$options.dirType === "rtl") {
+        this.resizeEventScrollType.e = true;
+        this.directionFunction = this.handleE;
+      } else {
+        this.resizeEventScrollType.w = true;
+        this.directionFunction = this.handleW;
+      }
     } else if (e.target.hasAttribute('class') && e.target.getAttribute('class').split(' ').indexOf('handle-s') > -1) {
       this.resizeEventScrollType.s = true;
       this.directionFunction = this.handleS;
     } else if (e.target.hasAttribute('class') && e.target.getAttribute('class').split(' ').indexOf('handle-e') > -1) {
-      this.resizeEventScrollType.e = true;
-      this.directionFunction = this.handleE;
+      if (this.gridster.$options.dirType === "rtl") {
+        this.resizeEventScrollType.w = true;
+        this.directionFunction = this.handleW;
+      } else {
+        this.resizeEventScrollType.e = true;
+        this.directionFunction = this.handleE;
+      }
     } else if (e.target.hasAttribute('class') && e.target.getAttribute('class').split(' ').indexOf('handle-nw') > -1) {
-      this.resizeEventScrollType.n = true;
-      this.resizeEventScrollType.w = true;
-      this.directionFunction = this.handleNW;
+      if (this.gridster.$options.dirType === "rtl") {
+        this.resizeEventScrollType.n = true;
+        this.resizeEventScrollType.e = true;
+        this.directionFunction = this.handleNE;
+      } else {
+        this.resizeEventScrollType.n = true;
+        this.resizeEventScrollType.w = true;
+        this.directionFunction = this.handleNW;
+      }
     } else if (e.target.hasAttribute('class') && e.target.getAttribute('class').split(' ').indexOf('handle-ne') > -1) {
-      this.resizeEventScrollType.n = true;
-      this.resizeEventScrollType.e = true;
-      this.directionFunction = this.handleNE;
+      if (this.gridster.$options.dirType === "rtl") {
+        this.resizeEventScrollType.n = true;
+        this.resizeEventScrollType.w = true;
+        this.directionFunction = this.handleNW;
+      } else {
+        this.resizeEventScrollType.n = true;
+        this.resizeEventScrollType.e = true;
+        this.directionFunction = this.handleNE;
+      }
     } else if (e.target.hasAttribute('class') && e.target.getAttribute('class').split(' ').indexOf('handle-sw') > -1) {
-      this.resizeEventScrollType.s = true;
-      this.resizeEventScrollType.w = true;
-      this.directionFunction = this.handleSW;
+      if (this.gridster.$options.dirType === "rtl") {
+        this.resizeEventScrollType.s = true;
+        this.resizeEventScrollType.e = true;
+        this.directionFunction = this.handleSE;
+      } else {
+        this.resizeEventScrollType.s = true;
+        this.resizeEventScrollType.w = true;
+        this.directionFunction = this.handleSW;
+      }
     } else if (e.target.hasAttribute('class') && e.target.getAttribute('class').split(' ').indexOf('handle-se') > -1) {
-      this.resizeEventScrollType.s = true;
-      this.resizeEventScrollType.e = true;
-      this.directionFunction = this.handleSE;
+      if (this.gridster.$options.dirType === "rtl") {
+        this.resizeEventScrollType.s = true;
+        this.resizeEventScrollType.w = true;
+        this.directionFunction = this.handleSW;
+      } else {
+        this.resizeEventScrollType.s = true;
+        this.resizeEventScrollType.e = true;
+        this.directionFunction = this.handleSE;
+      }
     }
   }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,5 +15,6 @@
   <a routerLink="/resize" routerLinkActive="active" mat-list-item> Resize</a>
   <a routerLink="/swap" routerLinkActive="active" mat-list-item> Swap</a>
   <a routerLink="/misc" routerLinkActive="active" mat-list-item> Misc</a>
+  <a routerLink="/rtl" routerLinkActive="active" mat-list-item> RTL</a>
 </mat-nav-list>
 <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import {MiscComponent} from './sections/misc/misc.component';
 import {PushComponent} from './sections/push/push.component';
 import {ResizeComponent} from './sections/resize/resize.component';
 import {SwapComponent} from './sections/swap/swap.component';
+import { RtlComponent } from './sections/rtl/rtl.component';
 
 const appRoutes: Routes = [
   {path: '', component: HomeComponent},
@@ -54,6 +55,7 @@ const appRoutes: Routes = [
   {path: 'resize', component: ResizeComponent},
   {path: 'swap', component: SwapComponent},
   {path: 'misc', component: MiscComponent},
+  {path: 'rtl', component: RtlComponent},
   {path: '**', redirectTo: ''}
 ];
 
@@ -80,6 +82,7 @@ const appRoutes: Routes = [
     ResizeComponent,
     SwapComponent,
     MiscComponent,
+    RtlComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/sections/api/api.component.ts
+++ b/src/app/sections/api/api.component.ts
@@ -14,6 +14,7 @@ export class ApiComponent implements OnInit {
   itemToPush: GridsterItemComponent;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       compactType: CompactType.None,

--- a/src/app/sections/compact/compact.component.ts
+++ b/src/app/sections/compact/compact.component.ts
@@ -13,6 +13,7 @@ export class CompactComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       compactType: CompactType.None,

--- a/src/app/sections/displayGrid/displayGrid.component.ts
+++ b/src/app/sections/displayGrid/displayGrid.component.ts
@@ -13,6 +13,7 @@ export class DisplayGridComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/drag/drag.component.ts
+++ b/src/app/sections/drag/drag.component.ts
@@ -25,6 +25,7 @@ export class DragComponent implements OnInit {
   }
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/dynamicWidgets/dynamicWidgets.component.ts
+++ b/src/app/sections/dynamicWidgets/dynamicWidgets.component.ts
@@ -14,6 +14,7 @@ export class DynamicWidgetsComponent implements OnInit {
   resizeEvent: EventEmitter<any> = new EventEmitter<any>();
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/emptyCell/emptyCell.component.ts
+++ b/src/app/sections/emptyCell/emptyCell.component.ts
@@ -13,6 +13,7 @@ export class EmptyCellComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/gridEvents/gridEvents.component.ts
+++ b/src/app/sections/gridEvents/gridEvents.component.ts
@@ -53,6 +53,7 @@ export class GridEventsComponent implements OnInit {
   }
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/gridMargins/gridMargins.component.ts
+++ b/src/app/sections/gridMargins/gridMargins.component.ts
@@ -13,6 +13,7 @@ export class GridMarginsComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/gridSizes/gridSizes.component.ts
+++ b/src/app/sections/gridSizes/gridSizes.component.ts
@@ -13,6 +13,7 @@ export class GridSizesComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/gridTypes/gridTypes.component.ts
+++ b/src/app/sections/gridTypes/gridTypes.component.ts
@@ -13,6 +13,7 @@ export class GridTypesComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/home/home.component.ts
+++ b/src/app/sections/home/home.component.ts
@@ -13,6 +13,7 @@ export class HomeComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       compactType: CompactType.None,

--- a/src/app/sections/items/items.component.ts
+++ b/src/app/sections/items/items.component.ts
@@ -17,6 +17,7 @@ export class ItemsComponent implements OnInit {
   }
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/misc/misc.component.ts
+++ b/src/app/sections/misc/misc.component.ts
@@ -13,6 +13,7 @@ export class MiscComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/push/push.component.ts
+++ b/src/app/sections/push/push.component.ts
@@ -13,6 +13,7 @@ export class PushComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/resize/resize.component.ts
+++ b/src/app/sections/resize/resize.component.ts
@@ -21,6 +21,7 @@ export class ResizeComponent implements OnInit {
   }
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,

--- a/src/app/sections/rtl/rtl.component.html
+++ b/src/app/sections/rtl/rtl.component.html
@@ -1,0 +1,94 @@
+<div class="options">
+    <a mat-raised-button href="https://github.com/tiberiuzuld/angular-gridster2/tree/master/src/app/sections/home"
+       target="_blank" class="source-code-button">
+      <mat-icon>open_in_new</mat-icon>
+      Source
+    </a>
+  </div>
+  <div class="options-header">
+    <mat-form-field>
+      <mat-select aria-label="Grid type" [(ngModel)]="options.gridType" (ngModelChange)="changedOptions()"
+                  placeholder="Grid Type">
+        <mat-option value="fit">Fit to screen</mat-option>
+        <mat-option value="scrollVertical">Scroll Vertical</mat-option>
+        <mat-option value="scrollHorizontal">Scroll Horizontal</mat-option>
+        <mat-option value="fixed">Fixed</mat-option>
+        <mat-option value="verticalFixed">Vertical Fixed</mat-option>
+        <mat-option value="horizontalFixed">Horizontal Fixed</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-select aria-label="Display grid lines" [(ngModel)]="options.displayGrid"
+                  placeholder="Display grid lines"
+                  (ngModelChange)="changedOptions()">
+        <mat-option value="always">Always</mat-option>
+        <mat-option value="onDrag&Resize">On Drag & Resize</mat-option>
+        <mat-option value="none">None</mat-option>
+      </mat-select>
+    </mat-form-field>
+  
+    <mat-checkbox [(ngModel)]="options.swap" (ngModelChange)="changedOptions()">
+      Swap Items
+    </mat-checkbox>
+    <mat-checkbox [(ngModel)]="options.pushItems" (ngModelChange)="changedOptions()">
+      Push Items
+    </mat-checkbox>
+    <mat-checkbox [(ngModel)]="options.draggable.enabled" *ngIf="options.draggable" (ngModelChange)="changedOptions()">
+      Drag Items
+    </mat-checkbox>
+    <mat-checkbox [(ngModel)]="options.resizable.enabled" *ngIf="options.resizable" (ngModelChange)="changedOptions()">
+      Resize Items
+    </mat-checkbox>
+    <mat-checkbox [(ngModel)]="options.pushResizeItems" (ngModelChange)="changedOptions()">
+      Push Resize Items
+    </mat-checkbox>
+    <mat-form-field>
+      <input matInput [(ngModel)]="options.margin" min="0" max="30" step="1" type="number" placeholder="Margin"
+             (ngModelChange)="changedOptions()">
+    </mat-form-field>
+    <mat-checkbox [(ngModel)]="options.outerMargin" (ngModelChange)="changedOptions()">Outer Margin</mat-checkbox>
+    <mat-form-field>
+      <input matInput [(ngModel)]="options.mobileBreakpoint" type="number" placeholder="Mobile Breakpoint"
+             (ngModelChange)="changedOptions()">
+    </mat-form-field>
+  
+    <mat-form-field>
+      <input matInput [(ngModel)]="options.fixedColWidth" type="number" placeholder="Fixed Col Width"
+             (ngModelChange)="changedOptions()">
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput [(ngModel)]="options.fixedRowHeight" type="number" placeholder="Fixed Row Height"
+             (ngModelChange)="changedOptions()">
+    </mat-form-field>
+    <button mat-mini-fab (click)="addItem()" class="add-button cols-2">
+      <mat-icon>add</mat-icon>
+    </button>
+  </div>
+  
+  <gridster [options]="options">
+    <gridster-item [item]="item" *ngFor="let item of dashboard">
+      <div class="button-holder">
+        <div class="gridster-item-content" *ngIf="item.hasContent">
+          <div class="stuff">
+            <span>Some content to select and click without dragging the widget</span>
+            <a href="https://www.google.com" target="_blank">Link to Google</a>
+          </div>
+        </div>
+        <div class="item-buttons" *ngIf="item.hasContent">
+          <button mat-icon-button mat-raised-button class="drag-handler">
+            <mat-icon>open_with</mat-icon>
+          </button>
+          <button mat-icon-button mat-raised-button class="remove-button" (mousedown)="removeItem($event, item)"
+                  (touchstart)="removeItem($event, item)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </div>
+        <label *ngIf="!item.hasContent">{{item.label}}</label>
+        <button mat-mini-fab *ngIf="!item.hasContent" (mousedown)="removeItem($event, item)"
+                (touchstart)="removeItem($event, item)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
+    </gridster-item>
+  </gridster>
+  

--- a/src/app/sections/rtl/rtl.component.ts
+++ b/src/app/sections/rtl/rtl.component.ts
@@ -66,7 +66,7 @@ export class RtlComponent implements OnInit {
       disableWindowResize: false,
       disableWarnings: false,
       scrollToNewItems: false,
-      dir: "rtl"
+      dirType: "rtl"
     };
 
     this.dashboard = [

--- a/src/app/sections/rtl/rtl.component.ts
+++ b/src/app/sections/rtl/rtl.component.ts
@@ -1,0 +1,116 @@
+import { Component, OnInit, ChangeDetectionStrategy, ViewEncapsulation } from '@angular/core';
+import { CompactType, DisplayGrid, GridsterConfig, GridsterItem, GridType } from 'angular-gridster2';
+@Component({
+  selector: 'app-rtl',
+  templateUrl: './rtl.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None
+})
+export class RtlComponent implements OnInit {
+  options: GridsterConfig;
+  dashboard: Array<GridsterItem>;
+
+  ngOnInit() {
+    document.body.setAttribute("dir", "rtl");
+
+    this.options = {
+      gridType: GridType.Fit,
+      compactType: CompactType.None,
+      margin: 10,
+      outerMargin: true,
+      outerMarginTop: null,
+      outerMarginRight: null,
+      outerMarginBottom: null,
+      outerMarginLeft: null,
+      useTransformPositioning: true,
+      mobileBreakpoint: 640,
+      minCols: 1,
+      maxCols: 100,
+      minRows: 1,
+      maxRows: 100,
+      maxItemCols: 100,
+      minItemCols: 1,
+      maxItemRows: 100,
+      minItemRows: 1,
+      maxItemArea: 2500,
+      minItemArea: 1,
+      defaultItemCols: 1,
+      defaultItemRows: 1,
+      fixedColWidth: 105,
+      fixedRowHeight: 105,
+      keepFixedHeightInMobile: false,
+      keepFixedWidthInMobile: false,
+      scrollSensitivity: 10,
+      scrollSpeed: 20,
+      enableEmptyCellClick: false,
+      enableEmptyCellContextMenu: false,
+      enableEmptyCellDrop: false,
+      enableEmptyCellDrag: false,
+      enableOccupiedCellDrop: false,
+      emptyCellDragMaxCols: 50,
+      emptyCellDragMaxRows: 50,
+      ignoreMarginInRow: false,
+      draggable: {
+        enabled: true,
+      },
+      resizable: {
+        enabled: true,
+      },
+      swap: false,
+      pushItems: true,
+      disablePushOnDrag: false,
+      disablePushOnResize: false,
+      pushDirections: { north: true, east: true, south: true, west: true },
+      pushResizeItems: false,
+      displayGrid: DisplayGrid.Always,
+      disableWindowResize: false,
+      disableWarnings: false,
+      scrollToNewItems: false,
+      dir: "rtl"
+    };
+
+    this.dashboard = [
+      { cols: 2, rows: 1, y: 0, x: 0 },
+      { cols: 2, rows: 2, y: 0, x: 2, hasContent: true },
+      { cols: 1, rows: 1, y: 0, x: 4 },
+      { cols: 1, rows: 1, y: 2, x: 5 },
+      { cols: 1, rows: 1, y: 1, x: 0 },
+      { cols: 1, rows: 1, y: 1, x: 0 },
+      { cols: 2, rows: 2, y: 3, x: 5, minItemRows: 2, minItemCols: 2, label: 'Min rows & cols = 2' },
+      { cols: 2, rows: 2, y: 2, x: 0, maxItemRows: 2, maxItemCols: 2, label: 'Max rows & cols = 2' },
+      { cols: 2, rows: 1, y: 2, x: 2, dragEnabled: true, resizeEnabled: true, label: 'Drag&Resize Enabled' },
+      { cols: 1, rows: 1, y: 2, x: 4, dragEnabled: false, resizeEnabled: false, label: 'Drag&Resize Disabled' },
+      { cols: 1, rows: 1, y: 2, x: 6 }
+    ];
+
+    this.dashboard = [
+      { cols: 2, rows: 1, y: 0, x: 0 },
+      { cols: 2, rows: 2, y: 0, x: 2, hasContent: true },
+      { cols: 1, rows: 1, y: 0, x: 4 },
+      { cols: 1, rows: 1, y: 2, x: 5 },
+      { cols: 1, rows: 1, y: 1, x: 0 },
+      { cols: 1, rows: 1, y: 1, x: 0 },
+      { cols: 2, rows: 2, y: 3, x: 5, minItemRows: 2, minItemCols: 2, label: 'Min rows & cols = 2' },
+      { cols: 2, rows: 2, y: 2, x: 0, maxItemRows: 2, maxItemCols: 2, label: 'Max rows & cols = 2' },
+      { cols: 2, rows: 1, y: 2, x: 2, dragEnabled: true, resizeEnabled: true, label: 'Drag&Resize Enabled' },
+      { cols: 1, rows: 1, y: 2, x: 4, dragEnabled: false, resizeEnabled: false, label: 'Drag&Resize Disabled' },
+      { cols: 1, rows: 1, y: 2, x: 6 }
+    ];
+  }
+
+  changedOptions() {
+    if (this.options.api && this.options.api.optionsChanged) {
+      this.options.api.optionsChanged();
+    }
+  }
+
+  removeItem($event, item) {
+    $event.preventDefault();
+    $event.stopPropagation();
+    this.dashboard.splice(this.dashboard.indexOf(item), 1);
+  }
+
+  addItem() {
+    this.dashboard.push({ x: 0, y: 0, cols: 1, rows: 1 });
+  }
+}

--- a/src/app/sections/swap/swap.component.ts
+++ b/src/app/sections/swap/swap.component.ts
@@ -13,6 +13,7 @@ export class SwapComponent implements OnInit {
   dashboard: Array<GridsterItem>;
 
   ngOnInit() {
+    document.body.removeAttribute("dir");
     this.options = {
       gridType: GridType.Fit,
       displayGrid: DisplayGrid.Always,


### PR DESCRIPTION
It ads RTL language support.

To enable it, `dirType` field added to options.

`export type dirTypes = 'ltr' | 'rtl';`

If dirType value is 'rtl', the gridster will work in accordance with 'rtl', if not, it won't change anything.

And also rtl component in src/app/section created and added to page. Its copy of home page but rtl.

![Screenshot_2](https://user-images.githubusercontent.com/48536631/70047438-21f4cf80-15d9-11ea-9445-b18e123a28cc.png)

____
Its works as expected but 
- [ ] gridsterResizable.service.ts needs to be updated. works the opposite way.

![ezgif-4-fb7b6b137058](https://user-images.githubusercontent.com/48536631/70047329-e823c900-15d8-11ea-9c7e-6375b8380c50.gif)

It might need some changes, @tiberiuzuld can you please check that.

Fix https://github.com/tiberiuzuld/angular-gridster2/issues/388 , https://github.com/tiberiuzuld/angular-gridster2/issues/569