### PR TITLE
Move the top/left assignment before itemInitCallback

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterItem.component.ts
+++ b/projects/angular-gridster2/src/lib/gridsterItem.component.ts
@@ -115,6 +115,9 @@ export class GridsterItemComponent implements OnInit, OnDestroy, OnChanges, Grid
     const width = this.$item.cols * this.gridster.curColWidth - this.gridster.$options.margin;
     const height = this.$item.rows * this.gridster.curRowHeight - this.gridster.$options.margin;
 
+    this.top = top;
+    this.left = left;
+
     if (!this.init && width > 0 && height > 0) {
       this.init = true;
       if (this.item.initCallback) {
@@ -134,8 +137,6 @@ export class GridsterItemComponent implements OnInit, OnDestroy, OnChanges, Grid
         this.gridster.options.itemResizeCallback(this.item, this);
       }
     }
-    this.top = top;
-    this.left = left;
   }
 
   itemChanged(): void {


### PR DESCRIPTION
Currently when the initItemCallback is called you have no access to the top/left values of the item.