### PR TITLE
Fixed Jumpy Scroll with setGridSize

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.component.ts
+++ b/projects/angular-gridster2/src/lib/gridster.component.ts
@@ -306,8 +306,6 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
     }
     this.gridRenderer.updateGridster();
 
-    this.updateGrid();
-
     if (this.$options.setGridSize) {
       this.renderer.addClass(this.el, 'gridSize');
       if (!this.mobile) {
@@ -319,6 +317,7 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
       this.renderer.setStyle(this.el, 'width', '');
       this.renderer.setStyle(this.el, 'height', '');
     }
+    this.updateGrid();
 
     let widgetsIndex: number = this.grid.length - 1;
     let widget: GridsterItemComponentInterface;


### PR DESCRIPTION
Fixes #666

The problem occurred under specific circumstances that caused an infinite loop, something like this:

`resize()` -> `onResize()` -> `calculateLayout()` -> `resize()` -> `onResize()` -> etc.

That infinite loop was causing the grid to resize constantly, which gave the appearance of "jumpy" scroll behavior. The infinite loop occurs because the last `if` statement in `resize()` is only supposed to execute under certain conditions (the problematic condition in my case was `height !== this.curHeight`), and those conditions were met in every instance of the loop due to the fact that some variables were not properly updated (in my case, `this.curHeight` did not actually contain the current height; it was out of date).

The change I made here fixes the problem by updating the variables used in the `if` statement at the proper time via the `updateGrid()` method. This change breaks the infinite loop because the variables are up to date when the condition is evaluated, causing the `if` block not to execute, which means `onResize()` is not called after the first iteration.

Disclaimer: I am not familiar with this library beyond this specific bug -- I've barely even used it. I don't think my changes will interfere with any existing functionality, but I make no guarantees :)
