### PR TITLE
Fixed #610

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
@@ -298,7 +298,9 @@ export class GridsterResizable {
   }
 
   handleW(e: MouseEvent): void {
-    this.left = e.clientX + this.offsetLeft - this.diffLeft;
+    const clientX = this.gridster.$options.dirType === DirTypes.RTL ? this.originalClientX + (this.originalClientX - e.clientX) : e.clientX;
+    this.left = clientX + this.offsetLeft - this.diffLeft;
+
     this.width = this.right - this.left;
     if (this.minWidth > this.width) {
       this.width = this.minWidth;
@@ -354,7 +356,9 @@ export class GridsterResizable {
   }
 
   handleE(e: MouseEvent): void {
-    this.width = e.clientX + this.offsetLeft - this.diffRight - this.left;
+    const clientX = this.gridster.$options.dirType === DirTypes.RTL ? this.originalClientX + (this.originalClientX - e.clientX) : e.clientX;
+    this.width = clientX + this.offsetLeft - this.diffRight - this.left;
+    
     if (this.minWidth > this.width) {
       this.width = this.minWidth;
     }


### PR DESCRIPTION
Fixed #610

Resize Works In Opposite Direction If Direction is RTL. This was because the X coordinate change did not change in RTL mode. And in RTL mode, we have to add a negative offset in the right direction and add a positive offset in the left direction in the handleE to change the width. Same for left coord in handleW direction.