### PR TITLE
Grid Drag and Resize enabled priority

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterItem.component.ts
+++ b/projects/angular-gridster2/src/lib/gridsterItem.component.ts
@@ -169,13 +169,15 @@ export class GridsterItemComponent implements OnInit, OnDestroy, OnChanges, Grid
   }
 
   canBeDragged(): boolean {
-    return !this.gridster.mobile &&
-      (this.$item.dragEnabled === undefined ? this.gridster.$options.draggable.enabled : this.$item.dragEnabled);
+    const gridDragEnabled = this.gridster.$options.draggable.enabled;
+    const itemDragEnabled = this.$item.dragEnabled === undefined ? gridDragEnabled : this.$item.dragEnabled;
+    return !this.gridster.mobile && gridDragEnabled && itemDragEnabled;
   }
 
   canBeResized(): boolean {
-    return !this.gridster.mobile &&
-      (this.$item.resizeEnabled === undefined ? this.gridster.$options.resizable.enabled : this.$item.resizeEnabled);
+    const gridResizable = this.gridster.$options.resizable.enabled;
+    const itemResizable = this.$item.resizeEnabled === undefined ? gridResizable : this.$item.resizeEnabled;
+    return !this.gridster.mobile && gridResizable && itemResizable;
   }
 
   bringToFront(offset: number): void {


### PR DESCRIPTION
I have changed the logic so that the grids drag and resize enabled settings are prioritised over the items. This has helped me as I am able to enable/disable editing on my grid and when enabled the items settings are taken into account. Happy for you to reject this change is you do not wish for it to be the desired behavior. 