### PR TITLE
Prevent window resize callback when gridster isn't document child #742

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.component.ts
+++ b/projects/angular-gridster2/src/lib/gridster.component.ts
@@ -188,12 +188,14 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
   }
 
   onResize(): void {
-    if (this.options.setGridSize) { // reset width/height so the size is recalculated afterwards
-      this.renderer.setStyle(this.el, 'width', '');
-      this.renderer.setStyle(this.el, 'height', '');
+    if (this.el.clientWidth) {
+      if (this.options.setGridSize) { // reset width/height so the size is recalculated afterwards
+        this.renderer.setStyle(this.el, 'width', '');
+        this.renderer.setStyle(this.el, 'height', '');
+      }
+      this.setGridSize();
+      this.calculateLayout();
     }
-    this.setGridSize();
-    this.calculateLayout();
   }
 
   checkIfToResize(): boolean {


### PR DESCRIPTION
If you use the gridster inside a material mat-tab, when the tab is not visible its content is removed from the dom but is not destroyed (to be reused the next time), this causes unnecessary resizes. If you use itemResizeCallback it may create problems.