### PR TITLE
(feat) Option for mobile breakpoint to be based on the body width

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.component.ts
+++ b/projects/angular-gridster2/src/lib/gridster.component.ts
@@ -215,6 +215,14 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
     return !horizontalScrollPresent;
   }
 
+  checkIfMobile(): boolean {
+    if (this.$options.useBodyForBreakpoint) {
+      return this.$options.mobileBreakpoint > document.body.clientWidth;
+    } else {
+      return this.$options.mobileBreakpoint > this.curWidth;
+    }
+  }
+
   setGridSize(): void {
     const el = this.el;
     let width;
@@ -232,10 +240,10 @@ export class GridsterComponent implements OnInit, OnChanges, OnDestroy, Gridster
 
   setGridDimensions(): void {
     this.setGridSize();
-    if (!this.mobile && this.$options.mobileBreakpoint > this.curWidth) {
+    if (!this.mobile && this.checkIfMobile()) {
       this.mobile = !this.mobile;
       this.renderer.addClass(this.el, 'mobile');
-    } else if (this.mobile && this.$options.mobileBreakpoint < this.curWidth) {
+    } else if (this.mobile && !this.checkIfMobile()) {
       this.mobile = !this.mobile;
       this.renderer.removeClass(this.el, 'mobile');
     }

--- a/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
@@ -15,6 +15,7 @@ export const GridsterConfigService: GridsterConfig = {
   setGridSize: false, // sets grid size depending on content
   compactType: CompactType.None, // compact items: 'none' | 'compactUp' | 'compactLeft' | 'compactUp&Left' | 'compactLeft&Up'
   mobileBreakpoint: 640, // if the screen is not wider that this, remove the grid layout and stack the items
+  useBodyForBreakpoint: false, // whether to use the body width to determine the mobile breakpoint. Uses the element width when false.
   allowMultiLayer: false,
   defaultLayerIndex: 0,
   maxLayerIndex: 2,

--- a/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
@@ -12,6 +12,7 @@ export interface GridsterConfigS {
   setGridSize: boolean;
   compactType: compactTypes;
   mobileBreakpoint: number;
+  useBodyForBreakpoint: boolean;
   allowMultiLayer: boolean;
   defaultLayerIndex: number;
   maxLayerIndex: number;

--- a/src/app/sections/gridTypes/gridTypes.component.html
+++ b/src/app/sections/gridTypes/gridTypes.component.html
@@ -40,6 +40,9 @@
   <mat-checkbox [(ngModel)]="options.keepFixedWidthInMobile" (ngModelChange)="changedOptions()">
     Keep Fixed Width In Mobile
   </mat-checkbox>
+  <mat-checkbox [(ngModel)]="options.useBodyForBreakpoint" (ngModelChange)="changedOptions()">
+    Use Body Width as Breakpoint
+  </mat-checkbox>
   <mat-form-field>
     <input matInput [(ngModel)]="options.mobileBreakpoint" type="number" placeholder="Mobile Breakpoint"
            (ngModelChange)="changedOptions()">

--- a/src/app/sections/gridTypes/gridTypes.component.ts
+++ b/src/app/sections/gridTypes/gridTypes.component.ts
@@ -21,6 +21,7 @@ export class GridTypesComponent implements OnInit {
       keepFixedHeightInMobile: false,
       keepFixedWidthInMobile: false,
       mobileBreakpoint: 640,
+      useBodyForBreakpoint: false,
       pushItems: true,
       rowHeightRatio: 1,
       draggable: {

--- a/src/app/sections/home/home.component.html
+++ b/src/app/sections/home/home.component.html
@@ -47,6 +47,8 @@
            (ngModelChange)="changedOptions()">
   </mat-form-field>
   <mat-checkbox [(ngModel)]="options.outerMargin" (ngModelChange)="changedOptions()">Outer Margin</mat-checkbox>
+
+  <mat-checkbox [(ngModel)]="options.useBodyForBreakpoint" (ngModelChange)="changedOptions()">Use Body Width as Breakpoint</mat-checkbox>
   <mat-form-field>
     <input matInput [(ngModel)]="options.mobileBreakpoint" type="number" placeholder="Mobile Breakpoint"
            (ngModelChange)="changedOptions()">

--- a/src/app/sections/home/home.component.ts
+++ b/src/app/sections/home/home.component.ts
@@ -30,6 +30,7 @@ export class HomeComponent implements OnInit {
       outerMarginLeft: null,
       useTransformPositioning: true,
       mobileBreakpoint: 640,
+      useBodyForBreakpoint: false,
       minCols: 1,
       maxCols: 100,
       minRows: 1,

--- a/src/assets/gridTypes.md
+++ b/src/assets/gridTypes.md
@@ -8,6 +8,7 @@
 | rowHeightRatio          | row height ratio from column width for gridType: `scrollVertical` and `scrollHorizontal` | Number  | 1       |
 | keepFixedHeightInMobile | keep the height from fixed gridType in mobile layout                                     | Boolean | false   |
 | keepFixedWidthInMobile  | keep the width from fixed gridType in mobile layout                                      | Boolean | false   |
+| useBodyForBreakpoint    | use the width of the `<body>` element to determine when to switch to the mobile layout   | Boolean | false   |
 | setGridSize             | sets grid size depending on content                                                      | Boolean | false   |
 | mobileBreakpoint        | if the screen is not wider that this, remove the grid layout and stack the items         | Number  | 640     |
 


### PR DESCRIPTION
Adds the "useBodyForBreakpoint" option, which switches the mobile breakpoint to be based on the width of the <body> element instead of the parent container element.

I have a use case where I would like the breakpoint to match my existing CSS media query breakpoints, and the width of the parent containing element can change based on opening and closing menus.  This would allow me to set the breakpoint of gridster to match my media queries, regardless of how wide the gridster parent element is.
