### PR TITLE
fix: Update project to use the correct file distributed by ngx-markdown.

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -31,7 +31,7 @@
               "src/theme.scss"
             ],
             "scripts": [
-              "node_modules/marked/lib/marked.js"
+              "node_modules/marked/marked.min.js"
             ]
           },
           "configurations": {
@@ -102,7 +102,7 @@
               "src/theme.scss"
             ],
             "scripts": [
-              "node_modules/marked/lib/marked.js"
+              "node_modules/marked/marked.min.js"
             ]
           }
         },


### PR DESCRIPTION
The related release of the ngx-markdown library uses the updated Marked library, which ships with marked.min.js instead of lib/marked.js.