### PR TITLE
feat: implement a functionality to enable boundary control for gridster items

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.constant.ts
@@ -118,6 +118,7 @@ export const GridsterConfigService: GridsterConfig = {
   scrollToNewItems: false, // scroll to new items placed in a scrollable view
   disableScrollHorizontal: false, // disable horizontal scrolling
   disableScrollVertical: false, // disable vertical scrolling
+  enableBoundaryControl: false, // enable boundary control while dragging items
   disableAutoPositionOnConflict: false, // disable auto-position of items on conflict state,
   dirType: DirTypes.LTR // page direction, rtl=right to left ltr= left to right, if you use rtl language set dirType to rtl
 };

--- a/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfig.interface.ts
@@ -138,6 +138,7 @@ export interface GridsterConfig {
   scrollToNewItems?: boolean;
   disableScrollHorizontal?: boolean;
   disableScrollVertical?: boolean;
+  enableBoundaryControl?: boolean;
   enableEmptyCellClick?: boolean;
   enableEmptyCellContextMenu?: boolean;
   enableEmptyCellDrop?: boolean;

--- a/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterConfigS.interface.ts
@@ -64,6 +64,7 @@ export interface GridsterConfigS {
   scrollToNewItems: boolean;
   disableScrollHorizontal?: boolean;
   disableScrollVertical?: boolean;
+  enableBoundaryControl?: boolean;
   enableEmptyCellClick: boolean;
   enableEmptyCellContextMenu: boolean;
   enableEmptyCellDrop: boolean;

--- a/src/app/sections/drag/drag.component.html
+++ b/src/app/sections/drag/drag.component.html
@@ -47,6 +47,12 @@
   >
     Disable Horizontal Scroll
   </mat-checkbox>
+  <mat-checkbox
+    [(ngModel)]="options.enableBoundaryControl"
+    (ngModelChange)="changedOptions()"
+  >
+    Enable Boundary Control
+  </mat-checkbox>
   <mat-form-field>
     <input
       matInput

--- a/src/assets/drag.md
+++ b/src/assets/drag.md
@@ -13,3 +13,4 @@
 | draggable.dropOverItemsCallback | callback when dragging an item drops over another item                              | Function(sourceItem, targetItem, grid) | undefined               |
 | disableScrollHorizontal         | enable/disable auto horizontal scrolling when on edge of grid                       | Boolean                                | false                   |
 | disableScrollVertical           | enable/disable auto vertical scrolling when on edge of grid                         | Boolean                                | false                   |
+| enableBoundaryControl           | enable/disable boundary control while dragging items                                | Boolean                                | false                   |


### PR DESCRIPTION
This PR aims to fix following issue: https://github.com/tiberiuzuld/angular-gridster2/issues/448

It provides a functionality which enables/disables the boundary control for draggable gridster items.