### PR TITLE
feat: extend gridster item configuration with resizable handles #807

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterItem.component.ts
+++ b/projects/angular-gridster2/src/lib/gridsterItem.component.ts
@@ -113,7 +113,17 @@ export class GridsterItemComponent
       maxItemCols: undefined,
       minItemCols: undefined,
       maxItemArea: undefined,
-      minItemArea: undefined
+      minItemArea: undefined,
+      resizableHandles: {
+        s: undefined,
+        e: undefined,
+        n: undefined,
+        w: undefined,
+        se: undefined,
+        ne: undefined,
+        sw: undefined,
+        nw: undefined
+      }
     });
   }
 
@@ -214,6 +224,21 @@ export class GridsterItemComponent
         ? gridResizable
         : this.$item.resizeEnabled;
     return !this.gridster.mobile && gridResizable && itemResizable;
+  }
+
+  getResizableHandles() {
+    const gridResizableHandles = this.gridster.$options.resizable.handles;
+    const itemResizableHandles = this.$item.resizableHandles;
+    // use grid settings if no settings are provided for the item.
+    if (itemResizableHandles === undefined) {
+      return gridResizableHandles;
+    }
+    // else merge the settings
+    return GridsterUtils.merge(
+      gridResizableHandles,
+      itemResizableHandles,
+      itemResizableHandles
+    );
   }
 
   bringToFront(offset: number): void {

--- a/projects/angular-gridster2/src/lib/gridsterItem.html
+++ b/projects/angular-gridster2/src/lib/gridsterItem.html
@@ -2,48 +2,48 @@
 <div
   (mousedown)="resize.dragStartDelay($event)"
   (touchstart)="resize.dragStartDelay($event)"
-  *ngIf="gridster.$options.resizable.handles.s && resize.resizeEnabled"
+  *ngIf="resize.resizableHandles?.s && resize.resizeEnabled"
   class="gridster-item-resizable-handler handle-s"
 ></div>
 <div
   (mousedown)="resize.dragStartDelay($event)"
   (touchstart)="resize.dragStartDelay($event)"
-  *ngIf="gridster.$options.resizable.handles.e && resize.resizeEnabled"
+  *ngIf="resize.resizableHandles?.e && resize.resizeEnabled"
   class="gridster-item-resizable-handler handle-e"
 ></div>
 <div
   (mousedown)="resize.dragStartDelay($event)"
   (touchstart)="resize.dragStartDelay($event)"
-  *ngIf="gridster.$options.resizable.handles.n && resize.resizeEnabled"
+  *ngIf="resize.resizableHandles?.n && resize.resizeEnabled"
   class="gridster-item-resizable-handler handle-n"
 ></div>
 <div
   (mousedown)="resize.dragStartDelay($event)"
   (touchstart)="resize.dragStartDelay($event)"
-  *ngIf="gridster.$options.resizable.handles.w && resize.resizeEnabled"
+  *ngIf="resize.resizableHandles?.w && resize.resizeEnabled"
   class="gridster-item-resizable-handler handle-w"
 ></div>
 <div
   (mousedown)="resize.dragStartDelay($event)"
   (touchstart)="resize.dragStartDelay($event)"
-  *ngIf="gridster.$options.resizable.handles.se && resize.resizeEnabled"
+  *ngIf="resize.resizableHandles?.se && resize.resizeEnabled"
   class="gridster-item-resizable-handler handle-se"
 ></div>
 <div
   (mousedown)="resize.dragStartDelay($event)"
   (touchstart)="resize.dragStartDelay($event)"
-  *ngIf="gridster.$options.resizable.handles.ne && resize.resizeEnabled"
+  *ngIf="resize.resizableHandles?.ne && resize.resizeEnabled"
   class="gridster-item-resizable-handler handle-ne"
 ></div>
 <div
   (mousedown)="resize.dragStartDelay($event)"
   (touchstart)="resize.dragStartDelay($event)"
-  *ngIf="gridster.$options.resizable.handles.sw && resize.resizeEnabled"
+  *ngIf="resize.resizableHandles?.sw && resize.resizeEnabled"
   class="gridster-item-resizable-handler handle-sw"
 ></div>
 <div
   (mousedown)="resize.dragStartDelay($event)"
   (touchstart)="resize.dragStartDelay($event)"
-  *ngIf="gridster.$options.resizable.handles.nw && resize.resizeEnabled"
+  *ngIf="resize.resizableHandles?.nw && resize.resizeEnabled"
   class="gridster-item-resizable-handler handle-nw"
 ></div>

--- a/projects/angular-gridster2/src/lib/gridsterItem.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterItem.interface.ts
@@ -19,6 +19,16 @@ export abstract class GridsterItemComponentInterface {
   checkItemChanges: (newValue: GridsterItem, oldValue: GridsterItem) => void;
   canBeDragged: () => boolean;
   canBeResized: () => boolean;
+  getResizableHandles: () => {
+    s: boolean;
+    e: boolean;
+    n: boolean;
+    w: boolean;
+    se: boolean;
+    ne: boolean;
+    sw: boolean;
+    nw: boolean;
+  };
   bringToFront: (offset: number) => void;
   sendToBack: (v: number) => void;
   el: HTMLElement;
@@ -38,6 +48,16 @@ export interface GridsterItem {
   ) => void;
   dragEnabled?: boolean;
   resizeEnabled?: boolean;
+  resizableHandles?: {
+    s?: boolean;
+    e?: boolean;
+    n?: boolean;
+    w?: boolean;
+    se?: boolean;
+    ne?: boolean;
+    sw?: boolean;
+    nw?: boolean;
+  };
   compactEnabled?: boolean;
   maxItemRows?: number;
   minItemRows?: number;

--- a/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
@@ -29,6 +29,16 @@ export class GridsterResizable {
     | null = null;
 
   resizeEnabled: boolean;
+  resizableHandles: {
+    s: boolean;
+    e: boolean;
+    n: boolean;
+    w: boolean;
+    se: boolean;
+    ne: boolean;
+    sw: boolean;
+    nw: boolean;
+  };
   mousemove: () => void;
   mouseup: () => void;
   mouseleave: () => void;
@@ -332,7 +342,7 @@ export class GridsterResizable {
     this.push = null!;
     this.pushResize.destroy();
     this.pushResize = null!;
-  }
+  };
 
   makeResize = (): void => {
     this.gridsterItem.setSize();
@@ -346,7 +356,7 @@ export class GridsterResizable {
     this.push = null!;
     this.pushResize.destroy();
     this.pushResize = null!;
-  }
+  };
 
   private handleNorth = (e: MouseEvent): void => {
     this.top = e.clientY + this.offsetTop - this.diffTop;
@@ -536,6 +546,7 @@ export class GridsterResizable {
 
   toggle(): void {
     this.resizeEnabled = this.gridsterItem.canBeResized();
+    this.resizableHandles = this.gridsterItem.getResizableHandles();
   }
 
   dragStartDelay(e: MouseEvent | TouchEvent): void {

--- a/projects/angular-gridster2/src/lib/gridsterUtils.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterUtils.service.ts
@@ -6,6 +6,10 @@ export class GridsterUtils {
     for (const p in obj2) {
       if (obj2[p] !== void 0 && properties.hasOwnProperty(p)) {
         if (typeof obj2[p] === 'object') {
+          // create an empty object for the property if obj1 does not already have one.
+          if (!(p in obj1)) {
+            obj1[p] = {};
+          }
           obj1[p] = GridsterUtils.merge(obj1[p], obj2[p], properties[p]);
         } else {
           obj1[p] = obj2[p];

--- a/projects/angular-gridster2/src/lib/tests/gridsterUtils.service.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterUtils.service.spec.ts
@@ -38,6 +38,21 @@ describe('merge method', () => {
       JSON.stringify(GridsterUtils.merge(obj1, obj2, properties))
     ).not.toBe(JSON.stringify(properties));
   });
+  it("should check obj1 when typeof obj2['p'] == 'object and obj1 does not include 'p'", () => {
+    const obj1 = { key1: 'value1' };
+    const obj2 = { key1: 'value3', key2: 'value4', key3: { key4: 'value10' } };
+    const properties = { key1: 'value3', key3: { key4: 'value11' } };
+    const output = { key1: 'value3', key3: { key4: 'value10' } };
+    expect(JSON.stringify(GridsterUtils.merge(obj1, obj2, properties))).toBe(
+      JSON.stringify(output)
+    );
+    expect(
+      JSON.stringify(GridsterUtils.merge(obj1, obj2, properties))
+    ).not.toBe(JSON.stringify(obj2));
+    expect(
+      JSON.stringify(GridsterUtils.merge(obj1, obj2, properties))
+    ).not.toBe(JSON.stringify(properties));
+  });
 });
 
 describe('check touch event', () => {

--- a/src/app/sections/items/items.component.html
+++ b/src/app/sections/items/items.component.html
@@ -119,6 +119,56 @@
   >
     Compact
   </mat-checkbox>
+  <ng-container *ngIf="dashboard[0].resizableHandles">
+    <mat-checkbox
+      [(ngModel)]="dashboard[0].resizableHandles.s"
+      (ngModelChange)="changedOptions()"
+    >
+      Resize South
+    </mat-checkbox>
+    <mat-checkbox
+      [(ngModel)]="dashboard[0].resizableHandles.e"
+      (ngModelChange)="changedOptions()"
+    >
+      Resize East
+    </mat-checkbox>
+    <mat-checkbox
+      [(ngModel)]="dashboard[0].resizableHandles.n"
+      (ngModelChange)="changedOptions()"
+    >
+      Resize North
+    </mat-checkbox>
+    <mat-checkbox
+      [(ngModel)]="dashboard[0].resizableHandles.w"
+      (ngModelChange)="changedOptions()"
+    >
+      Resize West
+    </mat-checkbox>
+    <mat-checkbox
+      [(ngModel)]="dashboard[0].resizableHandles.se"
+      (ngModelChange)="changedOptions()"
+    >
+      Resize South-East
+    </mat-checkbox>
+    <mat-checkbox
+      [(ngModel)]="dashboard[0].resizableHandles.ne"
+      (ngModelChange)="changedOptions()"
+    >
+      Resize North-East
+    </mat-checkbox>
+    <mat-checkbox
+      [(ngModel)]="dashboard[0].resizableHandles.sw"
+      (ngModelChange)="changedOptions()"
+    >
+      Resize South-West
+    </mat-checkbox>
+    <mat-checkbox
+      [(ngModel)]="dashboard[0].resizableHandles.nw"
+      (ngModelChange)="changedOptions()"
+    >
+      Resize North-West
+    </mat-checkbox>
+  </ng-container>
   <mat-form-field>
     <mat-select
       aria-label="Compact type"

--- a/src/app/sections/items/items.component.ts
+++ b/src/app/sections/items/items.component.ts
@@ -72,7 +72,17 @@ export class ItemsComponent implements OnInit {
         maxItemArea: 2500,
         dragEnabled: true,
         resizeEnabled: true,
-        compactEnabled: true
+        compactEnabled: true,
+        resizableHandles: {
+          s: true,
+          e: true,
+          n: true,
+          w: true,
+          se: true,
+          ne: true,
+          sw: true,
+          nw: true
+        }
       },
       { cols: 2, rows: 2, y: 0, x: 2 },
       { cols: 1, rows: 1, y: 0, x: 4 },

--- a/src/assets/items.md
+++ b/src/assets/items.md
@@ -1,18 +1,19 @@
 ### Options
 
-| Option         | Description                                                         | Type                                          | Default   |
-| -------------- | ------------------------------------------------------------------- | --------------------------------------------- | --------- |
-| x              | x position if missing will auto position                            | Number                                        | undefined |
-| y              | y position if missing will auto position                            | Number                                        | undefined |
-| rows           | number of rows if missing will use grid option `defaultItemRows`    | Number                                        | undefined |
-| cols           | number of columns if missing will use grid option `defaultItemCols` | Number                                        | undefined |
-| minItemRows    | override grid option `minItemRows`                                  | Number                                        | undefined |
-| maxItemRows    | override grid option `maxItemRows`                                  | Number                                        | undefined |
-| minItemCols    | override grid option `minItemCols`                                  | Number                                        | undefined |
-| maxItemCols    | override grid option `maxItemCols`                                  | Number                                        | undefined |
-| minItemArea    | override grid option `minItemArea`                                  | Number                                        | undefined |
-| maxItemArea    | override grid option `maxItemArea`                                  | Number                                        | undefined |
-| dragEnabled    | override grid option `draggable.enabled`                            | Boolean                                       | undefined |
-| resizeEnabled  | override grid option `resizable.enabled`                            | Boolean                                       | undefined |
-| compactEnabled | disable grid option `compact` for this item                         | Boolean                                       | undefined |
-| initCallback   | initialization callback and has size > 0                            | Function(GridsterItem, GridsterItemComponent) | undefined |
+| Option           | Description                                                         | Type                                                                                                       | Default   |
+| ---------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------- |
+| x                | x position if missing will auto position                            | Number                                                                                                     | undefined |
+| y                | y position if missing will auto position                            | Number                                                                                                     | undefined |
+| rows             | number of rows if missing will use grid option `defaultItemRows`    | Number                                                                                                     | undefined |
+| cols             | number of columns if missing will use grid option `defaultItemCols` | Number                                                                                                     | undefined |
+| minItemRows      | override grid option `minItemRows`                                  | Number                                                                                                     | undefined |
+| maxItemRows      | override grid option `maxItemRows`                                  | Number                                                                                                     | undefined |
+| minItemCols      | override grid option `minItemCols`                                  | Number                                                                                                     | undefined |
+| maxItemCols      | override grid option `maxItemCols`                                  | Number                                                                                                     | undefined |
+| minItemArea      | override grid option `minItemArea`                                  | Number                                                                                                     | undefined |
+| maxItemArea      | override grid option `maxItemArea`                                  | Number                                                                                                     | undefined |
+| dragEnabled      | override grid option `draggable.enabled`                            | Boolean                                                                                                    | undefined |
+| resizeEnabled    | override grid option `resizable.enabled`                            | Boolean                                                                                                    | undefined |
+| compactEnabled   | disable grid option `compact` for this item                         | Boolean                                                                                                    | undefined |
+| initCallback     | initialization callback and has size > 0                            | Function(GridsterItem, GridsterItemComponent)                                                              | undefined |
+| resizableHandles | override grid option `resizable.handles` for this item              | Object {s: boolean, e: boolean, n: boolean, w: boolean, se: boolean, ne:boolean, sw: boolean, nw: boolean} | undefined |


### PR DESCRIPTION
It allows a gridster item to take a configuration for resizable handles which overrides the grid's **resizable.handles** option. 

Resolving #807. 
