### PR TITLE
bugfix:  The most bottom right gridster item in Gridster with boundary control is stuck and cannot be moved.

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
@@ -551,6 +551,10 @@ export class GridsterDraggable {
    * */
   private getDirections(e: MouseEvent) {
     const directions: string[] = [];
+     if (this.lastMouse.clientX === 0 && this.lastMouse.clientY === 0) {
+      this.lastMouse.clientY = e.clientY;
+      this.lastMouse.clientX = e.clientY;
+    }
     if (this.lastMouse.clientY > e.clientY) {
       directions.push(Direction.UP);
     }


### PR DESCRIPTION
*SYMPTOMS*
When you have boundary control enabled, the right bottom item was always stuck and couldn't be moved.

*ROOT CAUSE*
The root cause of the problem was that the last mouse event was:
`
this.lastMouse = {
   clientX: 0;
   clientY: 0;
}
`
Therefore we got the wrong directions in the `getDirections()` function. And because the directions were the length of 0, the `lastMouse` variable wasn't updated. And therefore the item is stuck.

*SOLUTION*
In the `getDirections()` method I have added checking,  that if lastMouse clientX and clientY are 0, we update it, and it gives us the right directions and also the items are moved in the right way.

*HOW TO VERIFY*
- *Steps to reproduce*
    1.  Make a gridster grid with a few items. Like in the screenshot below.
    2. Try to move most right and bottom gridster items. It sometimes/most of the time gets stuck.
- *Test without the fix*
It gets stuck and cannot be moved most of the time.
- *Test with the fix*
It can be moved normally.

![image](https://user-images.githubusercontent.com/32010556/182146599-fd9309d3-97c9-4d70-a069-487f8af52bef.png)


