### PR TITLE
fix: dropOverItemsCallback when you return to the cell from which you…

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
@@ -451,6 +451,11 @@ export class GridsterDraggable {
         });
       }
       this.push.checkPushBack();
+    } else {
+      // reset the collision when you drag and drop on an adjacent cell that is not empty
+      // and go back to the cell you were in from the beginning,
+      // this is to prevent `dropOverItemsCallback'
+      this.collision = false;
     }
     this.gridster.previewStyle(true);
   }


### PR DESCRIPTION
When you drag and drop on a cell that is not empty and you return to the initial position, there is a bug on `dropOverItemsCallback`, because the last valid position was the current one, the collision is not deleted and `dropOverItemsCallback` is called on the current position but with the value of to another position.

Below is a gif of how it reproduces:
![before](https://user-images.githubusercontent.com/19764133/183027157-2a7ce3a9-82e2-49f0-813e-58674bf205f8.gif)

After fix:
![after](https://user-images.githubusercontent.com/19764133/183027179-2cec70ce-9dc5-46bb-8128-1e93d81aa90c.gif)

