### PR TITLE
Bugfix: Fix griditem resizing into another item with northwest handle

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
@@ -383,6 +383,7 @@ export class GridsterResizable {
       if (this.gridster.checkCollision(this.gridsterItem.$item)) {
         this.gridsterItem.$item.y = this.itemBackup[1];
         this.gridsterItem.$item.rows = this.itemBackup[3];
+        this.top = this.gridster.positionYToPixels(this.gridsterItem.$item.y);
         this.setItemTop(
           this.gridster.positionYToPixels(this.gridsterItem.$item.y)
         );
@@ -431,6 +432,7 @@ export class GridsterResizable {
       if (this.gridster.checkCollision(this.gridsterItem.$item)) {
         this.gridsterItem.$item.x = this.itemBackup[0];
         this.gridsterItem.$item.cols = this.itemBackup[2];
+        this.left = this.gridster.positionXToPixels(this.gridsterItem.$item.x);
         this.setItemLeft(
           this.gridster.positionXToPixels(this.gridsterItem.$item.x)
         );


### PR DESCRIPTION
![chrome_BbyjeBl3qP](https://user-images.githubusercontent.com/34389995/216834200-159f2583-bc0a-4e1a-84fb-54bbc1d8c20a.gif)
**Issue:**
When an item is resized using northwest handle into another item from below then there is an overlap. This only happens only to north west handle.
**Rootcause:**
To handle north west we are handling north and west separately. 
```ts
  private handleNorthWest = (e: MouseEvent): void => {
    this.handleNorth(e);
    this.handleWest(e);
  };
```
When handling north we find collision due to above scenario and we dont update top position of the item due to [return;](https://github.com/tiberiuzuld/angular-gridster2/blob/master/projects/angular-gridster2/src/lib/gridsterResizable.service.ts#L393). When handling west there is no collision so it updates the item [left value](https://github.com/tiberiuzuld/angular-gridster2/blob/master/projects/angular-gridster2/src/lib/gridsterResizable.service.ts#L448). But it also updates item's [top](https://github.com/tiberiuzuld/angular-gridster2/blob/master/projects/angular-gridster2/src/lib/gridsterResizable.service.ts#L653) value also.
**Fix:**
Update this.top with correct value during handling of top collision so that when handling west the updates this.top value is used when updating the left position of item..