### PR TITLE
Bugfix: Added implementation for outermargins when dragging or resizing a grid item

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
@@ -27,6 +27,10 @@ export class GridsterDraggable {
   offsetLeft: number;
   offsetTop: number;
   margin: number;
+  outerMarginTop: number | null;
+  outerMarginRight: number | null;
+  outerMarginBottom: number | null;
+  outerMarginLeft: number | null;
   diffTop: number;
   diffLeft: number;
   originalClientX: number;
@@ -140,6 +144,10 @@ export class GridsterDraggable {
       'gridster-item-moving'
     );
     this.margin = this.gridster.$options.margin;
+    this.outerMarginTop = this.gridster.$options.outerMarginTop;
+    this.outerMarginRight = this.gridster.$options.outerMarginRight;
+    this.outerMarginBottom = this.gridster.$options.outerMarginBottom;
+    this.outerMarginLeft = this.gridster.$options.outerMarginLeft;
     this.offsetLeft = this.gridster.el.scrollLeft - this.gridster.el.offsetLeft;
     this.offsetTop = this.gridster.el.scrollTop - this.gridster.el.offsetTop;
     this.left = this.gridsterItem.left - this.margin;
@@ -180,7 +188,8 @@ export class GridsterDraggable {
       if (
         directions.includes(Direction.UP) &&
         this.gridsterItem.el.getBoundingClientRect().top <
-          this.gridster.el.getBoundingClientRect().top + this.margin
+          this.gridster.el.getBoundingClientRect().top +
+            (this.outerMarginTop ?? this.margin)
       ) {
         directions = directions.filter(direction => direction != Direction.UP);
         e = new MouseEvent(e.type, {
@@ -192,7 +201,8 @@ export class GridsterDraggable {
       if (
         directions.includes(Direction.LEFT) &&
         this.gridsterItem.el.getBoundingClientRect().left <
-          this.gridster.el.getBoundingClientRect().left + this.margin
+          this.gridster.el.getBoundingClientRect().left +
+            (this.outerMarginLeft ?? this.margin)
       ) {
         directions = directions.filter(
           direction => direction != Direction.LEFT
@@ -206,7 +216,8 @@ export class GridsterDraggable {
       if (
         directions.includes(Direction.RIGHT) &&
         this.gridsterItem.el.getBoundingClientRect().right >
-          this.gridster.el.getBoundingClientRect().right - this.margin
+          this.gridster.el.getBoundingClientRect().right -
+            (this.outerMarginRight ?? this.margin)
       ) {
         directions = directions.filter(
           direction => direction != Direction.RIGHT
@@ -220,7 +231,8 @@ export class GridsterDraggable {
       if (
         directions.includes(Direction.DOWN) &&
         this.gridsterItem.el.getBoundingClientRect().bottom >
-          this.gridster.el.getBoundingClientRect().bottom - this.margin
+          this.gridster.el.getBoundingClientRect().bottom - 
+            (this.outerMarginBottom ?? this.margin)
       ) {
         directions = directions.filter(
           direction => direction != Direction.DOWN

--- a/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
@@ -57,6 +57,10 @@ export class GridsterResizable {
   diffRight: number;
   diffBottom: number;
   margin: number;
+  outerMarginTop: number | null;
+  outerMarginRight: number | null;
+  outerMarginBottom: number | null;
+  outerMarginLeft: number | null;
   originalClientX: number;
   originalClientY: number;
   top: number;
@@ -162,6 +166,10 @@ export class GridsterResizable {
     this.bottom = this.gridsterItem.top + this.gridsterItem.height;
     this.right = this.gridsterItem.left + this.gridsterItem.width;
     this.margin = this.gridster.$options.margin;
+    this.outerMarginTop = this.gridster.$options.outerMarginTop;
+    this.outerMarginRight = this.gridster.$options.outerMarginRight;
+    this.outerMarginBottom = this.gridster.$options.outerMarginBottom;
+    this.outerMarginLeft = this.gridster.$options.outerMarginLeft;
     this.offsetLeft = this.gridster.el.scrollLeft - this.gridster.el.offsetLeft;
     this.offsetTop = this.gridster.el.scrollTop - this.gridster.el.offsetTop;
     this.diffLeft = e.clientX + this.offsetLeft - this.left;
@@ -466,10 +474,11 @@ export class GridsterResizable {
     }
     this.bottom = this.top + this.height;
     if (this.gridster.options.enableBoundaryControl) {
+      const margin = this.outerMarginBottom ?? this.margin;
       const box = this.gridster.el.getBoundingClientRect();
       this.bottom = Math.min(
         this.bottom,
-        box.bottom - box.top - 2 * this.margin
+        box.bottom - box.top - 2 * margin
       );
       this.height = this.bottom - this.top;
     }
@@ -518,8 +527,9 @@ export class GridsterResizable {
     }
     this.right = this.left + this.width;
     if (this.gridster.options.enableBoundaryControl) {
+      const margin = this.outerMarginRight ?? this.margin;
       const box = this.gridster.el.getBoundingClientRect();
-      this.right = Math.min(this.right, box.right - box.left - 2 * this.margin);
+      this.right = Math.min(this.right, box.right - box.left - 2 * margin);
       this.width = this.right - this.left;
     }
     const marginRight = this.gridster.options.pushItems ? 0 : this.margin;


### PR DESCRIPTION
When both margin and outermargin is given along with boundarycontrol, then when resizing and dragging the grid item doesnt fit in target position. It leaves some gap as the outermargins given in grid options are not being considered.