### PR TITLE
feat: improve the grid responsiveness by caching and reusing the last…

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterRenderer.interface.ts
+++ b/projects/angular-gridster2/src/lib/gridsterRenderer.interface.ts
@@ -1,0 +1,17 @@
+export interface CommonGridStyle {
+  [key: string]: string;
+}
+
+export interface CommonGridCachedStyle {
+  width: number;
+  height: number;
+  style: CommonGridStyle;
+}
+
+export interface GridColumnCachedStyle extends CommonGridCachedStyle {
+  left: number;
+}
+
+export interface GridRowCachedStyle extends CommonGridCachedStyle {
+  top: number;
+}


### PR DESCRIPTION
The getGridColumnStyle and getGridRowStyle methods from GridsterRenderer service that are used in HTML through ngStyle directive are not optimized and in some cases is crashing the app and browser by continuously calling these two methods over and over, and reason of this is that these methods are returning a new objects every time and Angular understands that there is a change and this process never stops.
To improve this behavior I added a cache for the last calculated style and reuse the last style if not changed.

This issue was discovered in a hybrid Angular project with AngularJs and Angular 14 and the problem occurred only on downgraded gridster components, while on components not downgraded was working as expected. I suspect that this is caused by different ways of handling change detections and rendering between AngularJs and Angular 14.