### PR TITLE
chore: adapt gridster component to the newest angular guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ What Angular supports [here](https://github.com/angular/angular)
 
 ```javascript
 import {Component} from '@angular/core';
-import {GridsterComponent, GridsterItemComponent} from 'angular-gridster2';
+import {Gridster, GridsterItemComponent} from 'angular-gridster2';
 
 @Component({
   standalone: true,
-  imports: [GridsterComponent, GridsterItemComponent],
+  imports: [Gridster, GridsterItemComponent],
   ...
 })
 ```

--- a/projects/angular-gridster2/src/lib/gridster.html
+++ b/projects/angular-gridster2/src/lib/gridster.html
@@ -1,14 +1,15 @@
-@for (column of gridColumns; track i; let i = $index) {
+@for (_ of gridColumns; track i; let i = $index) {
 <div
   class="gridster-column"
   [ngStyle]="gridRenderer.getGridColumnStyle(i)"
 ></div>
-} @for (row of gridRows; track i; let i = $index) {
+} @for (_ of gridRows; track i; let i = $index) {
 <div class="gridster-row" [ngStyle]="gridRenderer.getGridRowStyle(i)"></div>
 }
-<ng-content></ng-content>
+<ng-content />
+
 <gridster-preview
+  class="gridster-preview"
   [gridRenderer]="gridRenderer"
   [previewStyle$]="previewStyle$"
-  class="gridster-preview"
-></gridster-preview>
+/>

--- a/projects/angular-gridster2/src/lib/gridster.module.ts
+++ b/projects/angular-gridster2/src/lib/gridster.module.ts
@@ -1,10 +1,10 @@
 import { NgModule } from '@angular/core';
 
-import { GridsterComponent } from './gridster.component';
+import { Gridster } from './gridster';
 import { GridsterItemComponent } from './gridsterItem.component';
 
 @NgModule({
-  imports: [GridsterComponent, GridsterItemComponent],
-  exports: [GridsterComponent, GridsterItemComponent]
+  imports: [Gridster, GridsterItemComponent],
+  exports: [Gridster, GridsterItemComponent]
 })
 export class GridsterModule {}

--- a/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.service.ts
@@ -302,7 +302,9 @@ export class GridsterDraggable {
   calculateItemPositionWithoutScale(e: MouseEvent): void {
     const isRTL = this.gridster.$options.dirType === DirTypes.RTL;
     if (isRTL) {
-      this.left = this.gridster.el.offsetWidth - (e.clientX + this.offsetLeft - this.diffLeft);
+      this.left =
+        this.gridster.el.offsetWidth -
+        (e.clientX + this.offsetLeft - this.diffLeft);
     } else {
       this.left = e.clientX + this.offsetLeft - this.diffLeft;
     }

--- a/projects/angular-gridster2/src/lib/gridsterItem.component.ts
+++ b/projects/angular-gridster2/src/lib/gridsterItem.component.ts
@@ -14,7 +14,7 @@ import {
   SimpleChanges,
   ViewEncapsulation
 } from '@angular/core';
-import { GridsterComponent } from './gridster.component';
+import { Gridster } from './gridster';
 
 import { GridsterDraggable } from './gridsterDraggable.service';
 import type { GridsterItem } from './gridsterItem.interface';
@@ -47,7 +47,7 @@ export class GridsterItemComponent
   }>();
   $item: GridsterItem;
   el: HTMLElement;
-  gridster: GridsterComponent;
+  gridster: Gridster;
   top: number;
   left: number;
   width: number;
@@ -64,7 +64,7 @@ export class GridsterItemComponent
 
   constructor(
     @Inject(ElementRef) el: ElementRef,
-    gridster: GridsterComponent,
+    gridster: Gridster,
     @Inject(Renderer2) public renderer: Renderer2,
     @Inject(NgZone) private zone: NgZone
   ) {

--- a/projects/angular-gridster2/src/lib/gridsterScroll.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterScroll.service.ts
@@ -83,11 +83,23 @@ export function scroll(
     const shouldScrollLeft = isRTL ? moveRight : moveLeft;
     if (shouldScrollRight && elemRightOffset <= scrollSensitivity) {
       cancelW();
-      if ((resizeEvent && resizeEventType && !resizeEventType.east) || intervalE) return;
+      if (
+        (resizeEvent && resizeEventType && !resizeEventType.east) ||
+        intervalE
+      )
+        return;
       intervalE = startHorizontal(1, calculateItemPosition, lastMouse, isRTL);
-    } else if (shouldScrollLeft && offsetLeft > 0 && elemLeftOffset < scrollSensitivity) {
+    } else if (
+      shouldScrollLeft &&
+      offsetLeft > 0 &&
+      elemLeftOffset < scrollSensitivity
+    ) {
       cancelE();
-      if ((resizeEvent && resizeEventType && !resizeEventType.west) || intervalW) return;
+      if (
+        (resizeEvent && resizeEventType && !resizeEventType.west) ||
+        intervalW
+      )
+        return;
       intervalW = startHorizontal(-1, calculateItemPosition, lastMouse, isRTL);
     } else if (lastMouse.clientX !== clientX) {
       cancelHorizontal();

--- a/projects/angular-gridster2/src/lib/tests/gridsterCompact.service.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterCompact.service.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   CompactType,
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterItem,
   GridsterItemComponent,
   GridsterItemComponentInterface,
@@ -22,7 +22,7 @@ function itemValidateCallback(
 }
 
 describe('gridsterCompact service', () => {
-  let fixture: ComponentFixture<GridsterComponent>;
+  let fixture: ComponentFixture<Gridster>;
   let gridsterComponent;
   let gridsterCompact;
 
@@ -31,15 +31,11 @@ describe('gridsterCompact service', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        GridsterComponent,
-        GridsterItemComponent,
-        GridsterPreviewComponent
-      ],
+      imports: [Gridster, GridsterItemComponent, GridsterPreviewComponent],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
 
-    fixture = TestBed.createComponent(GridsterComponent);
+    fixture = TestBed.createComponent(Gridster);
     gridsterComponent = fixture.componentInstance;
     gridsterComponent.options = {
       gridType: GridType.Fixed,

--- a/projects/angular-gridster2/src/public_api.ts
+++ b/projects/angular-gridster2/src/public_api.ts
@@ -2,7 +2,7 @@
  * Public API Surface of gridster
  */
 
-export { GridsterComponent } from './lib/gridster.component';
+export { Gridster } from './lib/gridster';
 export { GridsterItemComponent } from './lib/gridsterItem.component';
 export { GridsterItemComponentInterface } from './lib/gridsterItem.interface';
 export type { GridsterItem } from './lib/gridsterItem.interface';

--- a/src/app/sections/api/api.component.ts
+++ b/src/app/sections/api/api.component.ts
@@ -9,7 +9,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 import {
   CompactType,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -27,7 +27,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatButtonModule,
     MatIconModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/compact/compact.component.ts
+++ b/src/app/sections/compact/compact.component.ts
@@ -11,7 +11,7 @@ import { MatSelectModule } from '@angular/material/select';
 
 import {
   CompactType,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -30,7 +30,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatIconModule,
     MatSelectModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/displayGrid/displayGrid.component.ts
+++ b/src/app/sections/displayGrid/displayGrid.component.ts
@@ -11,7 +11,7 @@ import { MatSelectModule } from '@angular/material/select';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -30,7 +30,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatIconModule,
     MatSelectModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/drag/drag.component.ts
+++ b/src/app/sections/drag/drag.component.ts
@@ -13,7 +13,7 @@ import { MatInputModule } from '@angular/material/input';
 import {
   DisplayGrid,
   Draggable,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -38,7 +38,7 @@ interface Safe extends GridsterConfig {
     MatIconModule,
     MatInputModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })
@@ -65,7 +65,7 @@ export class DragComponent implements OnInit {
   static overlapEvent(
     source: GridsterItem,
     target: GridsterItem,
-    grid: GridsterComponent
+    grid: Gridster
   ): void {
     console.log('overlap', source, target, grid);
   }

--- a/src/app/sections/dynamicWidgets/dynamicWidgets.component.ts
+++ b/src/app/sections/dynamicWidgets/dynamicWidgets.component.ts
@@ -10,7 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -28,7 +28,7 @@ import { ParentDynamicComponent } from './parentDynamic.component';
     MatButtonModule,
     MatIconModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent,
     ParentDynamicComponent
   ]

--- a/src/app/sections/emptyCell/emptyCell.component.ts
+++ b/src/app/sections/emptyCell/emptyCell.component.ts
@@ -12,7 +12,7 @@ import { MatInputModule } from '@angular/material/input';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -32,7 +32,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatIconModule,
     MatInputModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/gridEvents/gridEvents.component.ts
+++ b/src/app/sections/gridEvents/gridEvents.component.ts
@@ -9,7 +9,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterComponentInterface,
   GridsterConfig,
   GridsterItem,
@@ -28,7 +28,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatButtonModule,
     MatIconModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/gridMargins/gridMargins.component.ts
+++ b/src/app/sections/gridMargins/gridMargins.component.ts
@@ -13,7 +13,7 @@ import { MatSelectModule } from '@angular/material/select';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -34,7 +34,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatInputModule,
     MatSelectModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/gridSizes/gridSizes.component.ts
+++ b/src/app/sections/gridSizes/gridSizes.component.ts
@@ -11,7 +11,7 @@ import { MatInputModule } from '@angular/material/input';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -30,7 +30,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatIconModule,
     MatInputModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/gridTypes/gridTypes.component.ts
+++ b/src/app/sections/gridTypes/gridTypes.component.ts
@@ -13,7 +13,7 @@ import { MatSelectModule } from '@angular/material/select';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -34,7 +34,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatInputModule,
     MatSelectModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/home/home.component.ts
+++ b/src/app/sections/home/home.component.ts
@@ -15,7 +15,7 @@ import {
   CompactType,
   DisplayGrid,
   Draggable,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -42,7 +42,7 @@ interface Safe extends GridsterConfig {
     MatIconModule,
     MatInputModule,
     MatSelectModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/items/items.component.ts
+++ b/src/app/sections/items/items.component.ts
@@ -14,7 +14,7 @@ import { MatSelectModule } from '@angular/material/select';
 import {
   CompactType,
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -36,7 +36,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatInputModule,
     MatSelectModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/misc/misc.component.ts
+++ b/src/app/sections/misc/misc.component.ts
@@ -13,7 +13,7 @@ import { MatSelectModule } from '@angular/material/select';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -34,7 +34,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatInputModule,
     MatSelectModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/multiLayer/multi-layer.component.ts
+++ b/src/app/sections/multiLayer/multi-layer.component.ts
@@ -11,7 +11,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -31,7 +31,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatIconModule,
     MatMenuModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/push/push.component.ts
+++ b/src/app/sections/push/push.component.ts
@@ -12,7 +12,7 @@ import { MatIconModule } from '@angular/material/icon';
 import {
   DisplayGrid,
   Draggable,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -39,7 +39,7 @@ interface Safe extends GridsterConfig {
     MatCheckboxModule,
     MatIconModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/resize/resize.component.ts
+++ b/src/app/sections/resize/resize.component.ts
@@ -12,7 +12,7 @@ import { MatInputModule } from '@angular/material/input';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -51,7 +51,7 @@ interface Safe extends GridsterConfig {
     MatIconModule,
     MatInputModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/rtl/rtl.component.ts
+++ b/src/app/sections/rtl/rtl.component.ts
@@ -16,7 +16,7 @@ import {
   DirTypes,
   DisplayGrid,
   Draggable,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -43,7 +43,7 @@ interface Safe extends GridsterConfig {
     MatInputModule,
     MatSelectModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/swap/swap.component.ts
+++ b/src/app/sections/swap/swap.component.ts
@@ -11,7 +11,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 import {
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -30,7 +30,7 @@ import { MarkdownModule } from 'ngx-markdown';
     MatCheckboxModule,
     MatIconModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent
   ]
 })

--- a/src/app/sections/trackBy/trackBy.component.ts
+++ b/src/app/sections/trackBy/trackBy.component.ts
@@ -10,7 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
 import {
   CompactType,
   DisplayGrid,
-  GridsterComponent,
+  Gridster,
   GridsterConfig,
   GridsterItem,
   GridsterItemComponent,
@@ -29,7 +29,7 @@ import { TrackByItemComponent } from './trackByItem.component';
     MatButtonModule,
     MatIconModule,
     MarkdownModule,
-    GridsterComponent,
+    Gridster,
     GridsterItemComponent,
     TrackByItemComponent
   ]


### PR DESCRIPTION
Since angular is currently moving with quite a rapid pace a lot of components in this lib no longer fit the newest angular guidelines:

E.g.

- The new style guide of angluar (https://angular.dev/style-guide) removes the post fix from components/services…
- It is now preferred to use injection via functions rather than component constructors (https://angular.dev/style-guide#prefer-the-inject-function-over-constructor-parameter-injection) 
- Angular now supports self closing html tags making things cleaner for the template (https://angular.dev/reference/migrations/self-closing-tags#)
- Migrating to singal inputs (https://angular.dev/reference/migrations/signal-inputs#)

Since there are no contribution rules / guidelines for this repo and I'm not sure if this is direction you want to take, I only did a small sample on how it would look like. If this works for you I'm willing to adapt the rest of the project as well in a follow up pull request ( or maybe multiple since this would be hard to review otherwise)

What I did:

- Rename GridsterComponent -> Gridster
- Refactor to constructor-less setup with injection function
- Template cleanup


Btw, Im not sure if it is my setup but the test cases seem to no longer run out of the box, I had to install the " @angular-devkit/build-angular" dev dependency to be able to run them. 