### PR TITLE
fix: remove preview on item remove

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.html
+++ b/projects/angular-gridster2/src/lib/gridster.html
@@ -9,6 +9,5 @@
 <ng-content></ng-content>
 <gridster-preview
   [gridRenderer]="gridRenderer"
-  [previewStyle$]="previewStyle$"
   class="gridster-preview"
 ></gridster-preview>

--- a/projects/angular-gridster2/src/lib/gridsterPreview.component.ts
+++ b/projects/angular-gridster2/src/lib/gridsterPreview.component.ts
@@ -1,47 +1,31 @@
 import {
   Component,
   ElementRef,
-  EventEmitter,
   Input,
-  OnDestroy,
-  OnInit,
   Renderer2,
   ViewEncapsulation
 } from '@angular/core';
-import { Subscription } from 'rxjs';
 import { GridsterItem } from './gridsterItem.interface';
 import { GridsterRenderer } from './gridsterRenderer.service';
 
 @Component({
   selector: 'gridster-preview',
   template: '',
-  styleUrls: ['./gridsterPreview.css'],
-  encapsulation: ViewEncapsulation.None,
-  standalone: true
+  styleUrl: './gridsterPreview.css',
+  encapsulation: ViewEncapsulation.None
 })
-export class GridsterPreviewComponent implements OnInit, OnDestroy {
-  @Input() previewStyle$: EventEmitter<GridsterItem | null>;
+export class GridsterPreviewComponent {
   @Input() gridRenderer: GridsterRenderer;
   private el: HTMLElement;
-  private sub: Subscription;
 
-  constructor(el: ElementRef, private renderer: Renderer2) {
+  constructor(
+    el: ElementRef,
+    private renderer: Renderer2
+  ) {
     this.el = el.nativeElement;
   }
 
-  ngOnInit(): void {
-    this.sub = this.previewStyle$.subscribe(options =>
-      this.previewStyle(options)
-    );
-  }
-
-  ngOnDestroy(): void {
-    if(this.sub) {
-      this.sub.unsubscribe();
-    }
-  }
-
-  private previewStyle(item: GridsterItem | null): void {
+  previewStyle(item: GridsterItem | null): void {
     if (item) {
       this.renderer.setStyle(this.el, 'display', 'block');
       this.gridRenderer.updateItem(this.el, item, this.renderer);


### PR DESCRIPTION
 The gridster component does not update the item preview if the remove call is async.

### Steps to reproduce:

1. Go to any gridster demo (e.g. drag.component.html)
2. Change the "removeItem" callback from (mousedown) event to (click). e.g.:
`
            
            <button 
              mat-icon-button
              class="remove-button"
              (click)="removeItem($event, item)"
              (touchstart)="removeItem($event, item)"
            >
              <mat-icon>delete</mat-icon>
            </button>`

3. After clicking the remove button the preview will still be there: 
<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/836ae656-7eff-4d29-a74e-534435ccdf36" />

### What I did:

I adjusted the "removeItem" function which is called on item destruction to test for this case and adapt the preview style. 

I replaced the Behavior Subject it with a native angular viewChild function and directly calling the previewStyles function. This allows us to also cleanup the whole subscription management.


This fix should also address [Issue 516](https://github.com/tiberiuzuld/angular-gridster2/issues/516) and probably [Issue 479](https://github.com/tiberiuzuld/angular-gridster2/issues/479)