### PR TITLE
fix: item displayed at wrong position after no push resize (#944)

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.service.ts
@@ -612,7 +612,7 @@ export class GridsterResizable {
     if (this.gridsterItem.$item.x !== this.itemBackup.x) {
       this.gridsterItem.$item.x = this.itemBackup.x;
       if (!soft) {
-        this.left = this.gridster.positionXToPixels(this.gridsterItem.$item.y);
+        this.left = this.gridster.positionXToPixels(this.gridsterItem.$item.x);
         this.setItemLeft(this.left);
       }
     }


### PR DESCRIPTION
Fixes issue [944](https://github.com/tiberiuzuld/angular-gridster2/issues/944)

A simple mix up with x and y coordinate when resetting the item position