### PR TITLE
fix: inverted push direction

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterPush.ts
+++ b/projects/angular-gridster2/src/lib/gridsterPush.ts
@@ -18,10 +18,10 @@ export class GridsterPush {
     fromNorth: ((gridsterItemCollide: GridsterItem, gridsterItem: GridsterItem) => boolean)[];
     fromSouth: ((gridsterItemCollide: GridsterItem, gridsterItem: GridsterItem) => boolean)[];
   } = {
-    fromEast: [this.tryWest, this.trySouth, this.tryNorth, this.tryEast],
-    fromWest: [this.tryEast, this.trySouth, this.tryNorth, this.tryWest],
-    fromNorth: [this.trySouth, this.tryEast, this.tryWest, this.tryNorth],
-    fromSouth: [this.tryNorth, this.tryEast, this.tryWest, this.trySouth]
+    fromEast: [this.tryWest, this.trySouth, this.tryNorth],
+    fromWest: [this.tryEast, this.trySouth, this.tryNorth],
+    fromNorth: [this.trySouth, this.tryEast, this.tryWest],
+    fromSouth: [this.tryNorth, this.tryEast, this.tryWest]
   };
   private iteration = 0;
 
@@ -144,9 +144,6 @@ export class GridsterPush {
         this.pushedItemsOrder.push(itemCollision);
         pushedItems.push(itemCollision);
       } else if (this.tryPattern[direction][2].call(this, itemCollision, gridsterItem)) {
-        this.pushedItemsOrder.push(itemCollision);
-        pushedItems.push(itemCollision);
-      } else if (this.tryPattern[direction][3].call(this, itemCollision, gridsterItem)) {
         this.pushedItemsOrder.push(itemCollision);
         pushedItems.push(itemCollision);
       } else {


### PR DESCRIPTION
Hey, I was trying to fix #933.

What I notices is that the grid starts a recursive chain to pushes all items to the north and once it hit the border it works it self back from the top checking all the other possible solutions -> Leading to Number 1 being pushed down by Number 2 creating the swap effect.

There are multiple solution how this could be solved. E.g. we could track if the push would collide with there chained pushed coming from the opposite direction. 

But I was wondering what is the use case for this last check? In the code you are checking for swap in a separate function so there should not really be a need to check for a push in the direction you are coming from.

Can you please give a small example? Otherwise the code attach will fix the issue.

I create a patch file to test the issue. After applying you can find the test view under the path "/test"
[add_test_view.patch](https://github.com/user-attachments/files/23842553/add_test_view.patch)

 