### PR TITLE
fix(gridsterItem): fix z-index on moving/resizing items being overridden by inline style

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.ts
@@ -98,6 +98,7 @@ export class GridsterDraggable {
     this.touchend = this.gridsterItem.renderer.listen('document', 'touchend', this.dragStop);
     this.touchcancel = this.gridsterItem.renderer.listen('document', 'touchcancel', this.dragStop);
     this.gridsterItem.renderer.addClass(this.gridsterItem.el, 'gridster-item-moving');
+    this.gridsterItem.isMoving.set(true);
     this.margin = $options.margin;
     this.outerMarginTop = $options.outerMarginTop;
     this.outerMarginRight = $options.outerMarginRight;
@@ -242,6 +243,7 @@ export class GridsterDraggable {
     this.touchend();
     this.touchcancel();
     this.gridsterItem.renderer.removeClass(this.gridsterItem.el, 'gridster-item-moving');
+    this.gridsterItem.isMoving.set(false);
     this.gridster.dragInProgress = false;
     this.gridster.updateGrid();
     this.path = [];

--- a/projects/angular-gridster2/src/lib/gridsterItem.ts
+++ b/projects/angular-gridster2/src/lib/gridsterItem.ts
@@ -12,6 +12,7 @@ import {
   OnInit,
   output,
   Renderer2,
+  signal,
   Signal,
   untracked,
   ViewEncapsulation
@@ -91,10 +92,13 @@ export class GridsterItem implements OnInit, OnDestroy {
   resize: GridsterResizable = new GridsterResizable(this, this.gridster, this.zone);
   notPlaced: boolean;
   init: boolean;
+  isMoving = signal(false);
+  isResizing = signal(false);
 
-  zIndex(): number {
-    return this.getLayerIndex() + this.gridster.$options().baseLayerIndex;
-  }
+  zIndex = computed(() => {
+    const base = this.getLayerIndex() + this.gridster.$options().baseLayerIndex;
+    return this.isMoving() || this.isResizing() ? base + 1 : base;
+  });
 
   constructor() {
     effect(() => {

--- a/projects/angular-gridster2/src/lib/gridsterResizable.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.ts
@@ -107,6 +107,7 @@ export class GridsterResizable {
     this.touchcancel = this.gridsterItem.renderer.listen('document', 'touchcancel', this.dragStop);
 
     this.gridsterItem.renderer.addClass(this.gridsterItem.el, 'gridster-item-resizing');
+    this.gridsterItem.isResizing.set(true);
     this.lastMouse.clientX = e.clientX;
     this.lastMouse.clientY = e.clientY;
     this.left = this.gridsterItem.left;
@@ -258,6 +259,7 @@ export class GridsterResizable {
     }
     setTimeout(() => {
       this.gridsterItem.renderer.removeClass(this.gridsterItem.el, 'gridster-item-resizing');
+      this.gridsterItem.isResizing.set(false);
       if (this.gridster) {
         this.gridster.movingItem = null;
         this.gridster.previewStyle();


### PR DESCRIPTION
Fixes #982

`gridster-item-moving` and `gridster-item-resizing` CSS classes had no effect because the inline `z-index` style set on each item always overrides class-based styles.

**Root cause:** `zIndex()` was a plain method that returned `baseLayerIndex + layerIndex` unconditionally, and was bound via `[style.z-index]` directly. The CSS classes `.gridster-item-moving` / `.gridster-item-resizing` set `z-index: 2` but inline styles win in the cascade.

**Fix:**
- Add `isMoving` and `isResizing` signals to `GridsterItem`
- Convert `zIndex()` method to a `computed()` signal that bumps `z-index` by 1 when either flag is true
- Set `isMoving` / `isResizing` in `GridsterDraggable` and `GridsterResizable` at drag/resize start and stop

This makes the stacking order reactive and correct without touching the CSS.