### PR TITLE
[codex] fix fixed grid size without outer margin

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.ts
+++ b/projects/angular-gridster2/src/lib/gridster.ts
@@ -316,8 +316,9 @@ export class Gridster implements OnInit, OnDestroy {
     if ($options.setGridSize) {
       this.renderer.addClass(this.el, 'gridSize');
       if (!this.mobile) {
-        this.renderer.setStyle(this.el, 'width', this.columns * this.curColWidth + $options.margin + 'px');
-        this.renderer.setStyle(this.el, 'height', this.rows * this.curRowHeight + $options.margin + 'px');
+        const outerMarginSize = $options.outerMargin ? $options.margin : -$options.margin;
+        this.renderer.setStyle(this.el, 'width', this.columns * this.curColWidth + outerMarginSize + 'px');
+        this.renderer.setStyle(this.el, 'height', this.rows * this.curRowHeight + outerMarginSize + 'px');
       }
     } else {
       this.renderer.removeClass(this.el, 'gridSize');

--- a/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
@@ -41,4 +41,30 @@ describe('gridster component', () => {
     expect(gridsterComponent.el.style.width).toBe('210px');
     expect(gridsterComponent.el.style.height).toBe('210px');
   });
+
+  it('does not grow verticalFixed grid width on repeated layout', async () => {
+    Object.defineProperty(gridsterComponent.el, 'offsetWidth', {
+      configurable: true,
+      get: () => Number.parseFloat(gridsterComponent.el.style.width) || 300
+    });
+
+    fixture.componentRef.setInput('options', {
+      gridType: 'verticalFixed',
+      setGridSize: true,
+      outerMargin: false,
+      minCols: 2,
+      minRows: 2,
+      fixedRowHeight: 100,
+      mobileBreakpoint: 0,
+      margin: 10
+    });
+    fixture.detectChanges();
+
+    await fixture.whenStable();
+
+    gridsterComponent.api.calculateLayout();
+    gridsterComponent.api.calculateLayout();
+
+    expect(gridsterComponent.el.style.width).toBe('300px');
+  });
 });

--- a/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
@@ -1,0 +1,44 @@
+import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Gridster } from '../gridster';
+import { GridsterItem } from '../gridsterItem';
+import { GridsterPreview } from '../gridsterPreview';
+
+describe('gridster component', () => {
+  let fixture: ComponentFixture<Gridster>;
+  let gridsterComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+      imports: [Gridster, GridsterItem, GridsterPreview],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Gridster);
+    gridsterComponent = fixture.componentInstance;
+  });
+
+  it('excludes the unused outer margin from fixed grid size', async () => {
+    fixture.componentRef.setInput('options', {
+      gridType: 'fixed',
+      setGridSize: true,
+      outerMargin: false,
+      minCols: 2,
+      minRows: 2,
+      fixedColWidth: 100,
+      fixedRowHeight: 100,
+      mobileBreakpoint: 0,
+      margin: 10
+    });
+    fixture.detectChanges();
+
+    await fixture.whenStable();
+
+    gridsterComponent.api.calculateLayout();
+
+    expect(gridsterComponent.el.style.width).toBe('210px');
+    expect(gridsterComponent.el.style.height).toBe('210px');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #920 by excluding the unused outer margin from `setGridSize` dimensions when `outerMargin` is false.
- Also covers #845 by keeping `verticalFixed` + `setGridSize` from widening on repeated layout updates when the computed width feeds back into the next measurement.
- Keeps the existing extra outer margin when `outerMargin` is true.
- Adds component-level regression coverage for a 2x2 fixed grid with 100px cells and 10px margin sizing to 210px instead of 230px, plus a repeated-layout `verticalFixed` regression that stays at 300px.

## Checks
- `npm run test-lib -- --watch=false`
- `npm run build-lib`
- `npx eslint projects/angular-gridster2/src/lib/tests/gridster.spec.ts`

Note: focused lint on `gridster.ts` still hits pre-existing unrelated upstream lint errors (`component-selector`, `prefer-for-of`, etc.), so I kept the lint check scoped to the touched regression spec.