### PR TITLE
[codex] fix display grid width without outer margin

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterRenderer.ts
+++ b/projects/angular-gridster2/src/lib/gridsterRenderer.ts
@@ -153,11 +153,13 @@ export class GridsterRenderer {
   }
 
   getGridRowStyle(i: number): CommonGridStyle {
-    const margin = this.gridster.$options().margin;
+    const $options = this.gridster.$options();
+    const margin = $options.margin;
+    const trailingMargin = $options.outerMargin ? margin : -margin;
     // generates the new style
     const newPos: GridRowCachedStyle = {
       top: this.gridster.curRowHeight * i,
-      width: this.gridster.gridColumns.length * this.gridster.curColWidth + margin,
+      width: this.gridster.gridColumns.length * this.gridster.curColWidth + trailingMargin,
       height: this.gridster.curRowHeight - margin,
       style: {}
     };

--- a/projects/angular-gridster2/src/lib/tests/gridsterRenderer.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterRenderer.spec.ts
@@ -1,0 +1,21 @@
+import { signal } from '@angular/core';
+
+import { GridsterRenderer } from '../gridsterRenderer';
+
+describe('gridsterRenderer service', () => {
+  it('keeps display grid rows inside the usable width without outer margin', () => {
+    const gridster: any = {
+      $options: signal({
+        margin: 20,
+        outerMargin: false,
+        useTransformPositioning: true
+      }),
+      gridColumns: new Array(24),
+      curColWidth: 25,
+      curRowHeight: 61
+    };
+    const renderer = new GridsterRenderer(gridster);
+
+    expect(renderer.getGridRowStyle(0).width).toBe('580px');
+  });
+});


### PR DESCRIPTION
## Summary
- keep display-grid row overlays inside the usable grid width when outerMargin is false
- preserve the existing outer-margin row width behavior
- add a renderer regression for the 24-column verticalFixed case from #922

Fixes #922.

## Tests
- npm run test-lib -- --watch=false
- npm run build-lib