### PR TITLE
[codex] fix RTL empty-cell drop positioning

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterEmptyCell.ts
+++ b/projects/angular-gridster2/src/lib/gridsterEmptyCell.ts
@@ -1,4 +1,5 @@
 import { Gridster } from './gridster';
+import { DirTypes } from './gridsterConfig';
 import { GridsterItemConfig } from './gridsterItemConfig';
 import { GridsterUtils } from './gridsterUtils';
 
@@ -203,10 +204,14 @@ export class GridsterEmptyCell {
 
   getPixelsX(e: MouseEvent, rect: ClientRect): number {
     const scale = this.gridster.options().scale;
+    const $options = this.gridster.$options();
+    const leftMargin = this.gridster.gridRenderer.getLeftMargin();
+    const scrollOffset = this.gridster.el.scrollLeft - leftMargin;
+    const distanceFromEdge = $options.dirType === DirTypes.RTL ? rect.right - e.clientX : e.clientX - rect.left;
     if (scale) {
-      return (e.clientX - rect.left) / scale + this.gridster.el.scrollLeft - this.gridster.gridRenderer.getLeftMargin();
+      return distanceFromEdge / scale + scrollOffset;
     }
-    return e.clientX + this.gridster.el.scrollLeft - rect.left - this.gridster.gridRenderer.getLeftMargin();
+    return distanceFromEdge + scrollOffset;
   }
 
   getPixelsY(e: MouseEvent, rect: ClientRect): number {

--- a/projects/angular-gridster2/src/lib/tests/gridsterEmptyCell.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterEmptyCell.spec.ts
@@ -1,0 +1,38 @@
+import { signal } from '@angular/core';
+
+import { DirTypes } from '../gridsterConfig';
+import { GridsterEmptyCell } from '../gridsterEmptyCell';
+
+function createEmptyCell(dirType: DirTypes): GridsterEmptyCell {
+  const gridster: any = {
+    options: signal({ scale: 1 }),
+    $options: signal({ dirType }),
+    el: { scrollLeft: 0 },
+    gridRenderer: {
+      getLeftMargin: () => 0
+    }
+  };
+
+  return new GridsterEmptyCell(gridster);
+}
+
+describe('gridsterEmptyCell service', () => {
+  const rect = {
+    left: 0,
+    right: 400
+  } as ClientRect;
+
+  it('measures empty-cell drop positions from the left in LTR mode', () => {
+    const emptyCell = createEmptyCell(DirTypes.LTR);
+    const event = { clientX: 350 } as MouseEvent;
+
+    expect(emptyCell.getPixelsX(event, rect)).toBe(350);
+  });
+
+  it('measures empty-cell drop positions from the right in RTL mode', () => {
+    const emptyCell = createEmptyCell(DirTypes.RTL);
+    const event = { clientX: 350 } as MouseEvent;
+
+    expect(emptyCell.getPixelsX(event, rect)).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary
- measure empty-cell drop X coordinates from the right edge when dirType is RTL
- keep the existing LTR and scaled-coordinate behavior
- add RTL/LTR coverage for empty-cell X conversion

Fixes #909.

## Tests
- npm run test-lib -- --watch=false
- npm run build-lib