### PR TITLE
[codex] Stop drag on context menu

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.ts
@@ -45,6 +45,7 @@ export class GridsterDraggable {
   mousemove: () => void;
   mouseup: () => void;
   mouseleave: () => void;
+  contextmenu: () => void;
   cancelOnBlur: () => void;
   touchmove: () => void;
   touchend: () => void;
@@ -94,6 +95,7 @@ export class GridsterDraggable {
     });
     this.mouseup = this.gridsterItem.renderer.listen('document', 'mouseup', this.dragStop);
     this.mouseleave = this.gridsterItem.renderer.listen('document', 'mouseleave', this.dragStop);
+    this.contextmenu = this.gridsterItem.renderer.listen('document', 'contextmenu', this.dragStopOnContextMenu);
     this.cancelOnBlur = this.gridsterItem.renderer.listen('window', 'blur', this.dragStop);
     this.touchend = this.gridsterItem.renderer.listen('document', 'touchend', this.dragStop);
     this.touchcancel = this.gridsterItem.renderer.listen('document', 'touchcancel', this.dragStop);
@@ -229,15 +231,18 @@ export class GridsterDraggable {
     this.top = e.clientY + this.offsetTop - this.diffTop;
   }
 
-  dragStop = (e: MouseEvent): void => {
-    e.stopPropagation();
-    e.preventDefault();
+  dragStop = (e: MouseEvent, preventEvent = true): void => {
+    if (preventEvent) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
 
     cancelScroll();
     this.cancelOnBlur();
     this.mousemove();
     this.mouseup();
     this.mouseleave();
+    this.contextmenu();
     this.touchmove();
     this.touchend();
     this.touchcancel();
@@ -258,6 +263,10 @@ export class GridsterDraggable {
         this.cdRef.markForCheck();
       }
     });
+  };
+
+  dragStopOnContextMenu = (e: MouseEvent): void => {
+    this.dragStop(e, false);
   };
 
   cancelDrag = (): void => {

--- a/projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts
@@ -1,0 +1,104 @@
+import { GridsterDraggable } from '../gridsterDraggable';
+import { DirTypes } from '../gridsterConfig';
+
+describe('GridsterDraggable', () => {
+  it('stops an active drag on contextmenu without suppressing the menu event', () => {
+    const cleanupByEvent: Record<string, ReturnType<typeof vi.fn>> = {};
+    let contextMenuCallback: ((event: MouseEvent) => void) | undefined;
+
+    const renderer = {
+      addClass: vi.fn(),
+      removeClass: vi.fn(),
+      listen: vi.fn((target: unknown, eventName: string, callback: (event: MouseEvent) => void) => {
+        if (target === 'document' && eventName === 'contextmenu') {
+          contextMenuCallback = callback;
+        }
+        const cleanup = vi.fn();
+        cleanupByEvent[eventName] = cleanup;
+        return cleanup;
+      })
+    };
+    const item = { x: 0, y: 0, cols: 1, rows: 1 };
+    const $item = { ...item };
+    const gridster = {
+      dragInProgress: false,
+      movingItem: null,
+      el: {
+        offsetLeft: 0,
+        offsetTop: 0,
+        scrollLeft: 0,
+        scrollTop: 0,
+        scrollWidth: 500
+      },
+      options: vi.fn(() => ({
+        draggable: {
+          enabled: true
+        }
+      })),
+      $options: vi.fn(() => ({
+        margin: 0,
+        outerMarginTop: null,
+        outerMarginRight: null,
+        outerMarginBottom: null,
+        outerMarginLeft: null,
+        dirType: DirTypes.LTR,
+        draggable: {
+          dropOverItems: false
+        },
+        disablePushOnDrag: false,
+        pushItems: false,
+        pushDirections: { north: true, east: true, south: true, west: true },
+        swap: false
+      })),
+      previewStyle: vi.fn(),
+      updateGrid: vi.fn(),
+      checkGridCollision: vi.fn(() => false),
+      checkCollision: vi.fn(() => false),
+      findItemsWithItem: vi.fn(() => []),
+      renderer
+    };
+    const gridsterItem = {
+      gridster,
+      renderer,
+      el: document.createElement('div'),
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      item: vi.fn(() => item),
+      $item: vi.fn(() => $item),
+      setSize: vi.fn(),
+      checkItemChanges: vi.fn()
+    };
+    const zone = {
+      runOutsideAngular: (callback: () => void) => callback(),
+      run: (callback: () => void) => callback()
+    };
+    const cdRef = { markForCheck: vi.fn() };
+    const draggable = new GridsterDraggable(gridsterItem as never, gridster as never, zone as never, cdRef as never);
+    const dragStartEvent = {
+      which: 1,
+      clientX: 10,
+      clientY: 10,
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn()
+    } as unknown as MouseEvent;
+    const contextMenuEvent = {
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn()
+    } as unknown as MouseEvent;
+
+    draggable.dragStart(dragStartEvent);
+    contextMenuCallback?.(contextMenuEvent);
+
+    expect(contextMenuCallback).toBeDefined();
+    expect(contextMenuEvent.stopPropagation).not.toHaveBeenCalled();
+    expect(contextMenuEvent.preventDefault).not.toHaveBeenCalled();
+    expect(gridster.dragInProgress).toBe(false);
+    expect(cleanupByEvent.contextmenu).toHaveBeenCalledOnce();
+    expect(cleanupByEvent.mousemove).toHaveBeenCalledOnce();
+    expect(cleanupByEvent.mouseup).toHaveBeenCalledOnce();
+    expect(renderer.removeClass).toHaveBeenCalledWith(gridsterItem.el, 'gridster-item-moving');
+    expect(gridsterItem.checkItemChanges).toHaveBeenCalledWith($item, item);
+  });
+});


### PR DESCRIPTION
## Summary
- stop an active drag when a document context-menu event fires
- clean up the context-menu listener with the other drag listeners
- add regression coverage that right-click cleanup does not suppress the context-menu event itself

Fixes #880.

## Validation
- npm run test-lib -- --watch=false
- npm run build-lib
- npx eslint projects/angular-gridster2/src/lib/gridsterDraggable.ts projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts