### PR TITLE
[codex] Preserve existing item position checks

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.ts
+++ b/projects/angular-gridster2/src/lib/gridster.ts
@@ -401,7 +401,7 @@ export class Gridster implements OnInit, OnDestroy {
     }
   }
 
-  checkCollision(item: GridsterItemConfig, checkRatio?: boolean): GridsterItem | boolean {
+  checkCollision(item: GridsterItemConfig, checkRatio?: boolean, skipItem?: GridsterItem): GridsterItem | boolean {
     let collision: GridsterItem | boolean = false;
     const options = this.options();
     if (options.itemValidateCallback) {
@@ -411,7 +411,7 @@ export class Gridster implements OnInit, OnDestroy {
       collision = true;
     }
     if (!collision) {
-      const c = this.findItemWithItem(item);
+      const c = this.findItemWithItem(item, skipItem);
       if (c) {
         collision = c;
       }
@@ -445,10 +445,10 @@ export class Gridster implements OnInit, OnDestroy {
     return !(noNegativePosition && maxGridCols && maxGridRows && inRatio && inColsLimits && inRowsLimits && inMinArea && inMaxArea);
   }
 
-  findItemWithItem(item: GridsterItemConfig): GridsterItem | boolean {
+  findItemWithItem(item: GridsterItemConfig, skipItem?: GridsterItem): GridsterItem | boolean {
     for (let i = 0; i < this.grid.length; i++) {
       const widget = this.grid[i];
-      if (widget.$item() !== item && this.checkCollisionTwoItems(widget.$item(), item)) {
+      if (widget !== skipItem && widget.$item() !== item && this.checkCollisionTwoItems(widget.$item(), item)) {
         return widget;
       }
     }
@@ -489,11 +489,22 @@ export class Gridster implements OnInit, OnDestroy {
       newItem.rows = $options.defaultItemRows;
     }
     this.setGridDimensions();
+    const existingItemComponent = this.getItemComponent(newItem);
+    if (
+      existingItemComponent &&
+      startingFrom.y === undefined &&
+      startingFrom.x === undefined &&
+      newItem.y > -1 &&
+      newItem.x > -1 &&
+      !this.checkCollision(newItem, false, existingItemComponent)
+    ) {
+      return true;
+    }
     for (let y = startingFrom.y || 0; y < this.rows; y++) {
       newItem.y = y;
       for (let x = startingFrom.x || 0; x < this.columns; x++) {
         newItem.x = x;
-        if (!this.checkCollision(newItem)) {
+        if (!this.checkCollision(newItem, false, existingItemComponent)) {
           return true;
         }
       }

--- a/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
@@ -1,0 +1,62 @@
+import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Gridster } from '../gridster';
+import { GridsterItem } from '../gridsterItem';
+import { GridsterItemConfig } from '../gridsterItemConfig';
+import { GridsterPreview } from '../gridsterPreview';
+
+function createItemComponent(item: GridsterItemConfig) {
+  const $item = { ...item };
+  const itemComponent = {
+    $item: () => $item,
+    item: () => item,
+    setSize: vi.fn(),
+    drag: {
+      toggle: vi.fn()
+    },
+    resize: {
+      toggle: vi.fn()
+    },
+    notPlaced: false
+  } as unknown as GridsterItem;
+
+  return { $item, itemComponent };
+}
+
+describe('gridster component', () => {
+  let fixture: ComponentFixture<Gridster>;
+  let gridsterComponent: Gridster;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+      imports: [Gridster, GridsterItem, GridsterPreview],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Gridster);
+    gridsterComponent = fixture.componentInstance;
+    fixture.componentRef.setInput('options', {
+      mobileBreakpoint: 0,
+      minCols: 1,
+      minRows: 1,
+      maxCols: 100,
+      maxRows: 100
+    });
+    fixture.detectChanges();
+  });
+
+  it('does not move an existing item that already has a valid position', () => {
+    const firstItem = { x: 0, y: 0, cols: 1, rows: 1 };
+    const checkedItem = { x: 5, y: 3, cols: 2, rows: 1 };
+    const firstItemComponent = createItemComponent(firstItem);
+    const checkedItemComponent = createItemComponent(checkedItem);
+
+    gridsterComponent.grid = [firstItemComponent.itemComponent, checkedItemComponent.itemComponent];
+
+    expect(gridsterComponent.getNextPossiblePosition(checkedItem)).toBe(true);
+    expect(checkedItem).toEqual({ x: 5, y: 3, cols: 2, rows: 1 });
+    expect(checkedItemComponent.$item).toEqual({ x: 5, y: 3, cols: 2, rows: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- keep `getNextPossiblePosition(existingItem)` from moving an already valid dashboard item to the first open grid slot
- ignore the owning item component when collision-checking an existing item passed through the public API
- add a regression spec for checking an existing item without changing its `x`/`y`

Fixes #907.

## Root cause
`getNextPossiblePosition` searches from the top-left of the grid and mutates the item object as it searches. When callers pass an item that already belongs to the rendered dashboard just to check for available space, the method can treat the item as a new placement candidate and rewrite its coordinates.

## Validation
- `npm run test-lib -- --watch=false`
- `npm run build-lib`
- `npx eslint projects/angular-gridster2/src/lib/tests/gridster.spec.ts`
- `npx eslint projects/angular-gridster2/src/lib/gridster.ts projects/angular-gridster2/src/lib/tests/gridster.spec.ts` *(blocked by pre-existing upstream `gridster.ts` lint errors: component selector, prefer-for-of, no-inferrable-types, unused eslint-disable)*
- `git diff --check` *(only the repo's LF/CRLF warning)*