### PR TITLE
[codex] Preserve mobile item order

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.css
+++ b/projects/angular-gridster2/src/lib/gridster.css
@@ -28,6 +28,8 @@ gridster.fixed {
 }
 
 gridster.mobile {
+  display: flex;
+  flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;
 }

--- a/projects/angular-gridster2/src/lib/gridsterRenderer.ts
+++ b/projects/angular-gridster2/src/lib/gridsterRenderer.ts
@@ -35,6 +35,7 @@ export class GridsterRenderer {
         renderer.setStyle(el, 'width', '');
       }
 
+      renderer.setStyle(el, 'order', item.y * this.gridster.columns + item.x);
       renderer.setStyle(el, 'margin-bottom', $options.margin + 'px');
       renderer.setStyle(el, DirTypes.LTR ? 'margin-right' : 'margin-left', '');
     } else {
@@ -65,6 +66,7 @@ export class GridsterRenderer {
         }
       }
 
+      renderer.setStyle(el, 'order', null);
       renderer.setStyle(el, 'margin-bottom', marginBottom);
       renderer.setStyle(el, $options.dirType === DirTypes.LTR ? 'margin-right' : 'margin-left', marginRight);
     }

--- a/projects/angular-gridster2/src/lib/tests/gridsterRenderer.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterRenderer.spec.ts
@@ -1,0 +1,36 @@
+import { Renderer2 } from '@angular/core';
+
+import { Gridster } from '../gridster';
+import { DirTypes } from '../gridsterConfig';
+import { GridsterRenderer } from '../gridsterRenderer';
+
+function createRenderer() {
+  return {
+    setStyle: vi.fn()
+  } as unknown as Renderer2;
+}
+
+describe('GridsterRenderer', () => {
+  it('orders mobile items by their grid position', () => {
+    const gridster = {
+      mobile: true,
+      curWidth: 600,
+      columns: 12,
+      $options: () => ({
+        keepFixedHeightInMobile: false,
+        keepFixedWidthInMobile: false,
+        fixedColWidth: 100,
+        fixedRowHeight: 100,
+        margin: 10,
+        useTransformPositioning: true,
+        dirType: DirTypes.LTR
+      })
+    } as unknown as Gridster;
+    const renderer = createRenderer();
+    const el = document.createElement('gridster-item');
+
+    new GridsterRenderer(gridster).updateItem(el, { x: 2, y: 3, cols: 1, rows: 1 }, renderer);
+
+    expect(renderer.setStyle).toHaveBeenCalledWith(el, 'order', 38);
+  });
+});


### PR DESCRIPTION
## Summary
- stack mobile gridster items in a flex column so CSS ordering applies in mobile layout
- assign each mobile item a stable `order` from its desktop grid row/column position
- clear the order style when returning to the normal positioned grid layout
- add renderer coverage for row/column-derived mobile ordering

Fixes #924.

## Root cause
Mobile mode clears the absolute grid position and makes items relative, so the visible order falls back to dashboard array / DOM order. That can differ from the row/column order users see on desktop.

## Validation
- `npm run test-lib -- --watch=false`
- `npm run build-lib`
- `npx eslint projects/angular-gridster2/src/lib/gridsterRenderer.ts projects/angular-gridster2/src/lib/tests/gridsterRenderer.spec.ts`
- `git diff --check` *(only the repo's LF/CRLF warning)*