### PR TITLE
[codex] Preserve scroll rows during drag

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.ts
+++ b/projects/angular-gridster2/src/lib/gridster.ts
@@ -253,6 +253,9 @@ export class Gridster implements OnInit, OnDestroy {
       }
     }
     rows += $options.addEmptyRowsCount;
+    if (this.dragInProgress && $options.gridType === GridType.ScrollVertical) {
+      rows = Math.max(rows, this.rows);
+    }
     if (this.columns !== columns || this.rows !== rows) {
       this.columns = columns;
       this.rows = rows;

--- a/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
@@ -1,0 +1,54 @@
+import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Gridster } from '../gridster';
+import { GridType } from '../gridsterConfig';
+import { GridsterConfigService } from '../gridsterConfig.constant';
+import { GridsterItem } from '../gridsterItem';
+import { GridsterPreview } from '../gridsterPreview';
+
+describe('Gridster', () => {
+  let fixture: ComponentFixture<Gridster>;
+  let gridster: Gridster;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+      imports: [Gridster, GridsterItem, GridsterPreview],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Gridster);
+    gridster = fixture.componentInstance;
+    Object.defineProperty(gridster, 'options', {
+      value: signal({
+        ...GridsterConfigService,
+        gridType: GridType.ScrollVertical,
+        mobileBreakpoint: 0,
+        minRows: 1,
+        addEmptyRowsCount: 0,
+        disableWarnings: true
+      })
+    });
+  });
+
+  it('keeps scrollVertical rows from shrinking while dragging', () => {
+    gridster.rows = 12;
+    gridster.dragInProgress = true;
+    gridster.grid = [
+      {
+        notPlaced: false,
+        $item: () => ({ x: 0, y: 0, cols: 1, rows: 4 })
+      }
+    ] as unknown as GridsterItem[];
+
+    gridster.setGridDimensions();
+
+    expect(gridster.rows).toBe(12);
+
+    gridster.dragInProgress = false;
+    gridster.setGridDimensions();
+
+    expect(gridster.rows).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- keep `scrollVertical` row count from shrinking while an item is being dragged or resized
- still allow rows to grow during the active interaction
- allow the grid to shrink back to the actual content height once the interaction ends
- add component coverage for the mid-drag preserve and post-drag shrink behavior

Fixes #794.

## Root cause
`setGridDimensions()` recalculates row count from the current item positions on every layout update. In `scrollVertical`, dragging an item upward can reduce the computed row count while the pointer is still inside the grid, which shrinks the grid underneath the drag and amplifies the movement.

## Validation
- `npx prettier --check projects/angular-gridster2/src/lib/gridster.ts projects/angular-gridster2/src/lib/tests/gridster.spec.ts`
- `npx eslint projects/angular-gridster2/src/lib/tests/gridster.spec.ts` *(only the pre-existing Node module-type warning)*
- `npm run test-lib -- --watch=false`
- `npm run build-lib`
- `git diff --check` *(only the repo's LF/CRLF warning)*