### PR TITLE
fix: guard resize callbacks after teardown

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterResizable.ts
+++ b/projects/angular-gridster2/src/lib/gridsterResizable.ts
@@ -207,6 +207,10 @@ export class GridsterResizable {
   }
 
   dragMove = (e: MouseEvent): void => {
+    if (!this.gridster || !this.gridster.dragInProgress || !this.push || !this.pushResize) {
+      return;
+    }
+
     if (this.directionFunction === null) {
       throw new Error('The `directionFunction` has not been set before calling `dragMove`.');
     }
@@ -232,6 +236,10 @@ export class GridsterResizable {
   };
 
   dragStop = (e: MouseEvent): void => {
+    if (!this.gridster || !this.push || !this.pushResize) {
+      return;
+    }
+
     e.stopPropagation();
     e.preventDefault();
     cancelScroll();
@@ -266,6 +274,12 @@ export class GridsterResizable {
   };
 
   cancelResize = (): void => {
+    const push = this.push;
+    const pushResize = this.pushResize;
+    if (!push && !pushResize) {
+      return;
+    }
+
     const $item = this.gridsterItem.$item();
     const item = this.gridsterItem.item();
     $item.cols = item.cols || 1;
@@ -273,27 +287,49 @@ export class GridsterResizable {
     $item.x = item.x || 0;
     $item.y = item.y || 0;
     this.gridsterItem.setSize();
-    this.push.restoreItems();
-    this.pushResize.restoreItems();
-    this.push.destroy();
-    this.push = null!;
-    this.pushResize.destroy();
-    this.pushResize = null!;
+    if (push) {
+      push.restoreItems();
+      push.destroy();
+      this.push = null!;
+    }
+    if (pushResize) {
+      pushResize.restoreItems();
+      pushResize.destroy();
+      this.pushResize = null!;
+    }
+    this.directionFunction = null;
   };
 
   makeResize = (): void => {
+    const push = this.push;
+    const pushResize = this.pushResize;
+    if (!push && !pushResize) {
+      return;
+    }
+
     this.gridsterItem.setSize();
     this.gridsterItem.checkItemChanges(this.gridsterItem.$item(), this.gridsterItem.item());
-    this.push.setPushedItems();
-    this.pushResize.setPushedItems();
-    this.push.destroy();
-    this.push = null!;
-    this.pushResize.destroy();
-    this.pushResize = null!;
+    if (push) {
+      push.setPushedItems();
+      push.destroy();
+      this.push = null!;
+    }
+    if (pushResize) {
+      pushResize.setPushedItems();
+      pushResize.destroy();
+      this.pushResize = null!;
+    }
+    this.directionFunction = null;
   };
 
   private check = (direction: string): boolean => {
-    this.hasRatio && this.enforceAspectRatio();
+    if (!this.push || !this.pushResize) {
+      return false;
+    }
+
+    if (this.hasRatio) {
+      this.enforceAspectRatio();
+    }
     this.pushResize.pushItems(direction);
     this.push.pushItems(direction, this.gridster.$options().disablePushOnResize);
     if (this.gridster.checkCollision(this.gridsterItem.$item(), true)) {

--- a/projects/angular-gridster2/src/lib/tests/gridsterResizable.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterResizable.spec.ts
@@ -1,0 +1,64 @@
+import { NgZone } from '@angular/core';
+
+import { Gridster } from '../gridster';
+import { GridsterItem } from '../gridsterItem';
+import { GridsterResizable } from '../gridsterResizable';
+
+describe('GridsterResizable', () => {
+  interface ResizableInternals {
+    directionFunction: (event: Pick<MouseEvent, 'clientX' | 'clientY'>) => void;
+  }
+
+  function createResizable() {
+    const item = {
+      x: 1,
+      y: 1,
+      cols: 2,
+      rows: 2
+    };
+    const gridsterItem = {
+      item: vi.fn(() => item),
+      $item: vi.fn(() => ({ ...item })),
+      setSize: vi.fn(),
+      checkItemChanges: vi.fn()
+    };
+    const gridster = {
+      dragInProgress: false
+    };
+    const zone = {
+      run: vi.fn((callback: () => void) => callback()),
+      runOutsideAngular: vi.fn((callback: () => void) => callback())
+    };
+
+    return {
+      gridsterItem,
+      resizable: new GridsterResizable(gridsterItem as unknown as GridsterItem, gridster as unknown as Gridster, zone as unknown as NgZone)
+    };
+  }
+
+  it('ignores late move events after resize helpers are torn down', () => {
+    const { resizable } = createResizable();
+    const directionFunction = vi.fn();
+    (resizable as unknown as ResizableInternals).directionFunction = directionFunction;
+    const event = {
+      clientX: 100,
+      clientY: 100,
+      stopPropagation: vi.fn(),
+      preventDefault: vi.fn()
+    };
+
+    expect(() => resizable.dragMove(event as unknown as MouseEvent)).not.toThrow();
+    expect(directionFunction).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('ignores late resize callbacks after helpers are already destroyed', () => {
+    const { gridsterItem, resizable } = createResizable();
+
+    expect(() => resizable.makeResize()).not.toThrow();
+    expect(() => resizable.cancelResize()).not.toThrow();
+    expect(gridsterItem.setSize).not.toHaveBeenCalled();
+    expect(gridsterItem.checkItemChanges).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #889.

This updates the resize lifecycle to ignore late move/stop callbacks after the resize helpers have already been torn down. That mirrors the existing drag-side defensive behavior and prevents late iframe/container mouse events from trying to call `pushItems` or `setPushedItems` on destroyed helpers.

Changes:
- return early from late resize move/stop calls once teardown has happened
- make resize accept/cancel callbacks idempotent when helper objects are already gone
- reset the active resize direction after helper cleanup
- add focused regression coverage for late move and resize callbacks

Validation:
- `npx prettier --check projects/angular-gridster2/src/lib/gridsterResizable.ts projects/angular-gridster2/src/lib/tests/gridsterResizable.spec.ts`
- `npx eslint projects/angular-gridster2/src/lib/gridsterResizable.ts projects/angular-gridster2/src/lib/tests/gridsterResizable.spec.ts`
- `npm run test-lib -- --watch=false`
- `npm run build-lib`
- `git diff --check`

Note: I also tried the full `npm run lint -- --fix=false`; it still fails on existing unrelated repo lint issues in app templates and older library/tests files, while the touched files pass targeted eslint.