### PR TITLE
fix: expose calculateLayout on Gridster

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.ts
+++ b/projects/angular-gridster2/src/lib/gridster.ts
@@ -263,7 +263,7 @@ export class Gridster implements OnInit, OnDestroy {
     }
   }
 
-  private calculateLayout(): void {
+  calculateLayout(): void {
     if (this.compact) {
       this.compact.checkCompact();
     }

--- a/projects/angular-gridster2/src/lib/tests/gridsterPublicApi.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterPublicApi.spec.ts
@@ -1,0 +1,35 @@
+import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Gridster } from '../gridster';
+import { GridType } from '../gridsterConfig';
+import { GridsterConfigService } from '../gridsterConfig.constant';
+import { GridsterItem } from '../gridsterItem';
+import { GridsterPreview } from '../gridsterPreview';
+
+describe('Gridster public API', () => {
+  let fixture: ComponentFixture<Gridster>;
+  let gridster: Gridster;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+      imports: [Gridster, GridsterItem, GridsterPreview],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Gridster);
+    gridster = fixture.componentInstance;
+    Object.defineProperty(gridster, 'options', {
+      value: signal({
+        ...GridsterConfigService,
+        gridType: GridType.Fixed,
+        disableWarnings: true
+      })
+    });
+  });
+
+  it('exposes calculateLayout for ViewChild consumers', () => {
+    expect(() => gridster.calculateLayout()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #859.

`calculateLayout()` is already wired into the public `GridsterApi` object, but consumers who hold the component through `@ViewChild(Gridster)` could no longer call the method directly because the class method was private. This makes the existing method public again without changing its implementation.

Changes:
- expose `Gridster.calculateLayout()` on the component instance
- add a regression spec that calls `gridster.calculateLayout()` directly, so the spec fails to compile if the method becomes private again

Validation:
- `npx prettier --check projects/angular-gridster2/src/lib/gridster.ts projects/angular-gridster2/src/lib/tests/gridsterPublicApi.spec.ts`
- `npx eslint projects/angular-gridster2/src/lib/tests/gridsterPublicApi.spec.ts`
- `npm run test-lib -- --watch=false`
- `npm run build-lib`
- `git diff --check`