### PR TITLE
[codex] Refactor push pattern attempts into a loop

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterPush.ts
+++ b/projects/angular-gridster2/src/lib/gridsterPush.ts
@@ -2,10 +2,10 @@ import { Gridster } from './gridster';
 import { GridsterItem } from './gridsterItem';
 
 export class GridsterPush {
-  public fromSouth: string = 'fromSouth';
-  public fromNorth: string = 'fromNorth';
-  public fromEast: string = 'fromEast';
-  public fromWest: string = 'fromWest';
+  public fromSouth = 'fromSouth';
+  public fromNorth = 'fromNorth';
+  public fromEast = 'fromEast';
+  public fromWest = 'fromWest';
   private pushedItems: GridsterItem[] = [];
   private pushedItemsTemp: GridsterItem[] = [];
   private pushedItemsTempPath: { x: number; y: number }[][] = [];
@@ -137,19 +137,16 @@ export class GridsterPush {
         makePush = false;
         break;
       }
-      if (this.tryPattern[direction][0].call(this, itemCollision, gridsterItem)) {
-        this.pushedItemsOrder.push(itemCollision);
-        pushedItems.push(itemCollision);
-      } else if (this.tryPattern[direction][1].call(this, itemCollision, gridsterItem)) {
-        this.pushedItemsOrder.push(itemCollision);
-        pushedItems.push(itemCollision);
-      } else if (this.tryPattern[direction][2].call(this, itemCollision, gridsterItem)) {
-        this.pushedItemsOrder.push(itemCollision);
-        pushedItems.push(itemCollision);
-      } else if (this.tryPattern[direction][3].call(this, itemCollision, gridsterItem)) {
-        this.pushedItemsOrder.push(itemCollision);
-        pushedItems.push(itemCollision);
-      } else {
+      let pushed = false;
+      for (const tryPush of this.tryPattern[direction]) {
+        if (tryPush.call(this, itemCollision, gridsterItem)) {
+          this.pushedItemsOrder.push(itemCollision);
+          pushedItems.push(itemCollision);
+          pushed = true;
+          break;
+        }
+      }
+      if (!pushed) {
         makePush = false;
         break;
       }


### PR DESCRIPTION
## Summary
- replace the repeated push-pattern branch chain with a first-match loop
- keep the same push attempt order and rollback behavior
- remove trivial string type annotations in the touched file so focused lint passes

Fixes #943

## Validation
- npx prettier --check projects/angular-gridster2/src/lib/gridsterPush.ts
- npx eslint projects/angular-gridster2/src/lib/gridsterPush.ts
- git diff --check
- npm run test-lib -- --watch=false
- npm run build-lib