### PR TITLE
[codex] Clamp pixel positions to grid bounds

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.ts
+++ b/projects/angular-gridster2/src/lib/gridster.ts
@@ -544,7 +544,8 @@ export class Gridster implements OnInit, OnDestroy {
     if (noLimit) {
       return position;
     } else {
-      return Math.max(position, 0);
+      const maxPosition = Math.max(this.$options().maxCols - 1, 0);
+      return Math.min(Math.max(position, 0), maxPosition);
     }
   }
 
@@ -553,7 +554,8 @@ export class Gridster implements OnInit, OnDestroy {
     if (noLimit) {
       return position;
     } else {
-      return Math.max(position, 0);
+      const maxPosition = Math.max(this.$options().maxRows - 1, 0);
+      return Math.min(Math.max(position, 0), maxPosition);
     }
   }
 

--- a/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
@@ -1,0 +1,40 @@
+import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Gridster } from '../gridster';
+import { GridsterPreview } from '../gridsterPreview';
+
+describe('gridster position helpers', () => {
+  let fixture: ComponentFixture<Gridster>;
+  let gridsterComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+      imports: [Gridster, GridsterPreview],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Gridster);
+    gridsterComponent = fixture.componentInstance;
+    gridsterComponent.options = signal({
+      maxCols: 3,
+      maxRows: 2
+    });
+
+    await fixture.whenStable();
+
+    gridsterComponent.curColWidth = 100;
+    gridsterComponent.curRowHeight = 100;
+  });
+
+  it('should clamp pixel positions to the configured grid bounds', () => {
+    expect(gridsterComponent.pixelsToPositionX(260, Math.round)).toBe(2);
+    expect(gridsterComponent.pixelsToPositionY(160, Math.round)).toBe(1);
+  });
+
+  it('should allow unlimited pixel positions when noLimit is true', () => {
+    expect(gridsterComponent.pixelsToPositionX(260, Math.round, true)).toBe(3);
+    expect(gridsterComponent.pixelsToPositionY(160, Math.round, true)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- clamp pixel-derived grid positions to the configured max row/column index by default
- preserve raw conversion behavior for callers that pass `noLimit`
- add regression coverage for bottom/right edge rounding beyond configured bounds

Fixes #758

## Validation
- npx prettier --check projects/angular-gridster2/src/lib/gridster.ts projects/angular-gridster2/src/lib/tests/gridster.spec.ts
- npx eslint projects/angular-gridster2/src/lib/tests/gridster.spec.ts
- git diff --check
- npm run test-lib -- --watch=false
- npm run build-lib