### PR TITLE
[codex] Reset drag position after cancelled stop

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.ts
@@ -263,6 +263,8 @@ export class GridsterDraggable {
   cancelDrag = (): void => {
     this.gridsterItem.$item().x = this.gridsterItem.item().x || 0;
     this.gridsterItem.$item().y = this.gridsterItem.item().y || 0;
+    this.positionX = this.positionXBackup = this.gridsterItem.$item().x;
+    this.positionY = this.positionYBackup = this.gridsterItem.$item().y;
     this.gridsterItem.setSize();
     if (this.push) {
       this.push.restoreItems();

--- a/projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectorRef, NgZone } from '@angular/core';
+
+import { Gridster } from '../gridster';
+import { GridsterDraggable } from '../gridsterDraggable';
+import { GridsterItem } from '../gridsterItem';
+
+describe('gridsterDraggable service', () => {
+  it('should reset drag position fields when a drag is cancelled', () => {
+    const renderedItem = { x: 4, y: 5 };
+    const sourceItem = { x: 1, y: 2 };
+    const gridsterItem = {
+      $item: () => renderedItem,
+      item: () => sourceItem,
+      setSize: vi.fn()
+    } as unknown as GridsterItem;
+
+    const draggable = new GridsterDraggable(gridsterItem, {} as unknown as Gridster, {} as unknown as NgZone, {} as unknown as ChangeDetectorRef);
+    draggable.positionX = 4;
+    draggable.positionY = 5;
+    draggable.positionXBackup = 4;
+    draggable.positionYBackup = 5;
+
+    draggable.cancelDrag();
+
+    expect(renderedItem).toEqual(sourceItem);
+    expect(draggable.positionX).toBe(1);
+    expect(draggable.positionY).toBe(2);
+    expect(draggable.positionXBackup).toBe(1);
+    expect(draggable.positionYBackup).toBe(2);
+    expect(gridsterItem.setSize).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- reset draggable position bookkeeping when a rejected stop callback cancels a drag
- keep restored `$item` coordinates and exposed `drag.positionX/Y` in sync
- add regression coverage for cancelled drags

Fixes #694

## Validation
- `npx prettier --check projects/angular-gridster2/src/lib/gridsterDraggable.ts projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts`
- `npx eslint projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts`
- `git diff --check`
- `npm run test-lib -- --watch=false`
- `npm run build-lib`