### PR TITLE
[codex] Resize gridster when its host element changes

### DIFF
--- a/projects/angular-gridster2/src/lib/gridster.ts
+++ b/projects/angular-gridster2/src/lib/gridster.ts
@@ -80,6 +80,7 @@ export class Gridster implements OnInit, OnDestroy {
 
   private resize$ = new Subject<void>();
   private destroy$ = new Subject<void>();
+  private resizeObserver: ResizeObserver | null = null;
 
   constructor() {
     effect(() => {
@@ -145,6 +146,18 @@ export class Gridster implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe(() => this.resize());
+
+    this.observeElementResize();
+  }
+
+  private observeElementResize(): void {
+    if (typeof ResizeObserver === 'undefined' || this.resizeObserver) {
+      return;
+    }
+    this.zone.runOutsideAngular(() => {
+      this.resizeObserver = new ResizeObserver(() => this.onResize());
+      this.resizeObserver.observe(this.el);
+    });
   }
 
   private resize(): void {
@@ -166,6 +179,10 @@ export class Gridster implements OnInit, OnDestroy {
     this.destroy$.next();
     if (this.windowResize) {
       this.windowResize();
+    }
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
     }
     const options = this.options();
     if (options && options.destroyCallback) {

--- a/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridster.spec.ts
@@ -1,0 +1,68 @@
+import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Gridster } from '../gridster';
+import { GridType } from '../gridsterConfig';
+
+describe('gridster component', () => {
+  let fixture: ComponentFixture<Gridster>;
+  let resizeObserverCallback: ResizeObserverCallback;
+  let observe: ReturnType<typeof vi.fn>;
+  let disconnect: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    observe = vi.fn();
+    disconnect = vi.fn();
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeObserverCallback = callback;
+        }
+
+        observe = observe;
+        disconnect = disconnect;
+      }
+    );
+
+    await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+      imports: [Gridster],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Gridster);
+    fixture.componentInstance.options = signal({
+      disableWindowResize: true,
+      gridType: GridType.Fixed
+    }) as unknown as Gridster['options'];
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+    vi.unstubAllGlobals();
+    TestBed.resetTestingModule();
+  });
+
+  it('should resize when the gridster element changes size', () => {
+    const gridster = fixture.componentInstance;
+    const resize = vi.spyOn(gridster, 'onResize');
+
+    fixture.detectChanges();
+
+    expect(observe).toHaveBeenCalledWith(gridster.el);
+
+    resizeObserverCallback([], {} as ResizeObserver);
+
+    expect(resize).toHaveBeenCalled();
+  });
+
+  it('should disconnect the resize observer when destroyed', () => {
+    fixture.detectChanges();
+
+    fixture.destroy();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- observe the gridster host element with `ResizeObserver` when available
- call the existing resize path when the element changes size, so collapsible containers/layout panels are handled without relying on window resize
- disconnect the observer during component teardown
- add regression coverage for observer creation, resize callback forwarding, and cleanup

Fixes #824

## Validation
- `npx prettier --check projects/angular-gridster2/src/lib/gridster.ts projects/angular-gridster2/src/lib/tests/gridster.spec.ts`
- `npx eslint projects/angular-gridster2/src/lib/tests/gridster.spec.ts`
- `git diff --check`
- `npm run test-lib -- --watch=false`
- `npm run build-lib`