### PR TITLE
[codex] Reposition dragged item when grid scrolls

### DIFF
--- a/projects/angular-gridster2/src/lib/gridsterDraggable.ts
+++ b/projects/angular-gridster2/src/lib/gridsterDraggable.ts
@@ -10,6 +10,8 @@ import { GridsterUtils } from './gridsterUtils';
 
 const GRIDSTER_ITEM_RESIZABLE_HANDLER_CLASS = 'gridster-item-resizable-handler';
 
+type MousePosition = Pick<MouseEvent, 'clientX' | 'clientY'>;
+
 enum Direction {
   UP = 'UP',
   DOWN = 'DOWN',
@@ -51,6 +53,7 @@ export class GridsterDraggable {
   touchcancel: () => void;
   mousedown: () => void;
   touchstart: () => void;
+  scrollListener: () => void;
   push: GridsterPush;
   swap: GridsterSwap;
   path: { x: number; y: number }[] = [];
@@ -91,6 +94,7 @@ export class GridsterDraggable {
     this.zone.runOutsideAngular(() => {
       this.mousemove = this.gridsterItem.renderer.listen('document', 'mousemove', this.dragMove);
       this.touchmove = this.gridster.renderer.listen(this.gridster.el, 'touchmove', this.dragMove);
+      this.scrollListener = this.gridster.renderer.listen(this.gridster.el, 'scroll', this.dragScroll);
     });
     this.mouseup = this.gridsterItem.renderer.listen('document', 'mouseup', this.dragStop);
     this.mouseleave = this.gridsterItem.renderer.listen('document', 'mouseleave', this.dragStop);
@@ -109,6 +113,8 @@ export class GridsterDraggable {
     this.top = this.gridsterItem.top - this.margin;
     this.originalClientX = e.clientX;
     this.originalClientY = e.clientY;
+    this.lastMouse.clientX = e.clientX;
+    this.lastMouse.clientY = e.clientY;
     this.width = this.gridsterItem.width;
     this.height = this.gridsterItem.height;
     if ($options.dirType === DirTypes.RTL) {
@@ -196,7 +202,13 @@ export class GridsterDraggable {
     }
   };
 
-  calculateItemPositionFromMousePosition = (e: MouseEvent): void => {
+  dragScroll = (): void => {
+    this.offsetLeft = this.gridster.el.scrollLeft - this.gridster.el.offsetLeft;
+    this.offsetTop = this.gridster.el.scrollTop - this.gridster.el.offsetTop;
+    this.calculateItemPositionFromMousePosition(this.lastMouse);
+  };
+
+  calculateItemPositionFromMousePosition = (e: MousePosition): void => {
     const options = this.gridster.options();
     if (options.scale) {
       this.calculateItemPositionWithScale(e, options.scale);
@@ -209,7 +221,7 @@ export class GridsterDraggable {
     this.zone.run(() => this.gridster.updateGrid());
   };
 
-  calculateItemPositionWithScale(e: MouseEvent, scale: number): void {
+  calculateItemPositionWithScale(e: MousePosition, scale: number): void {
     if (this.gridster.$options().dirType === DirTypes.RTL) {
       this.left = this.gridster.el.scrollWidth - this.originalClientX + (e.clientX - this.originalClientX) / scale + this.diffLeft;
     } else {
@@ -218,7 +230,7 @@ export class GridsterDraggable {
     this.top = this.originalClientY + (e.clientY - this.originalClientY) / scale + this.offsetTop - this.diffTop;
   }
 
-  calculateItemPositionWithoutScale(e: MouseEvent): void {
+  calculateItemPositionWithoutScale(e: MousePosition): void {
     const isRTL = this.gridster.$options().dirType === DirTypes.RTL;
     if (isRTL) {
       this.left = this.gridster.el.offsetWidth - (e.clientX + this.offsetLeft - this.diffLeft);
@@ -239,6 +251,7 @@ export class GridsterDraggable {
     this.mouseup();
     this.mouseleave();
     this.touchmove();
+    this.scrollListener();
     this.touchend();
     this.touchcancel();
     this.gridsterItem.renderer.removeClass(this.gridsterItem.el, 'gridster-item-moving');

--- a/projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts
+++ b/projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts
@@ -1,0 +1,85 @@
+import { ChangeDetectorRef, NgZone } from '@angular/core';
+
+import { Gridster } from '../gridster';
+import { DirTypes } from '../gridsterConfig';
+import { GridsterDraggable } from '../gridsterDraggable';
+import { GridsterItem } from '../gridsterItem';
+import { GridsterPush } from '../gridsterPush';
+import { GridsterSwap } from '../gridsterSwap';
+
+describe('gridsterDraggable service', () => {
+  it('should reposition the dragged item when the grid scrolls without mouse movement', () => {
+    const renderedItem = { x: 0, y: 0, cols: 1, rows: 1 };
+    const sourceItem = { x: 0, y: 0, cols: 1, rows: 1 };
+    const setCellPosition = vi.fn();
+    const gridsterItem = {
+      top: 0,
+      left: 0,
+      width: 100,
+      height: 100,
+      el: document.createElement('div'),
+      renderer: {},
+      $item: () => renderedItem,
+      item: () => sourceItem
+    } as unknown as GridsterItem;
+    const gridster = {
+      el: {
+        scrollLeft: 0,
+        scrollTop: 100,
+        offsetLeft: 0,
+        offsetTop: 0,
+        scrollWidth: 1000,
+        offsetWidth: 300
+      },
+      options: () => ({}),
+      $options: () => ({
+        dirType: DirTypes.LTR,
+        disablePushOnDrag: false,
+        draggable: {
+          dropOverItems: false
+        }
+      }),
+      pixelsToPositionX: (position: number) => Math.round(position / 100),
+      pixelsToPositionY: (position: number) => Math.round(position / 100),
+      checkGridCollision: () => false,
+      checkCollision: () => false,
+      gridRenderer: {
+        setCellPosition
+      },
+      updateGrid: vi.fn(),
+      previewStyle: vi.fn()
+    } as unknown as Gridster;
+    const zone = {
+      run: (callback: () => void) => callback()
+    } as unknown as NgZone;
+    const draggable = new GridsterDraggable(gridsterItem, gridster, zone, {} as unknown as ChangeDetectorRef);
+    draggable.originalClientX = 10;
+    draggable.originalClientY = 10;
+    draggable.diffLeft = 10;
+    draggable.diffTop = 10;
+    draggable.offsetLeft = 0;
+    draggable.offsetTop = 0;
+    draggable.left = 0;
+    draggable.top = 0;
+    draggable.width = 100;
+    draggable.height = 100;
+    draggable.lastMouse = { clientX: 10, clientY: 10 };
+    draggable.path = [{ x: 0, y: 0 }];
+    draggable.push = {
+      fromWest: 'west',
+      fromEast: 'east',
+      fromNorth: 'north',
+      fromSouth: 'south',
+      pushItems: vi.fn(),
+      checkPushBack: vi.fn()
+    } as unknown as GridsterPush;
+    draggable.swap = {
+      swapItems: vi.fn()
+    } as unknown as GridsterSwap;
+
+    draggable.dragScroll();
+
+    expect(renderedItem.y).toBe(1);
+    expect(setCellPosition).toHaveBeenCalledWith(gridsterItem.renderer, gridsterItem.el, 0, 100);
+  });
+});


### PR DESCRIPTION
Fixes #735. When the grid scrolls while a drag is active, recalculate the dragged item from the last pointer position so the item keeps tracking the cursor instead of staying at the old scroll offset. The scroll listener is registered only for the active drag and removed with the existing drag listeners. Added a regression spec for scrolling without mouse movement. Validation: npx prettier --check projects/angular-gridster2/src/lib/gridsterDraggable.ts projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts; npx eslint projects/angular-gridster2/src/lib/gridsterDraggable.ts projects/angular-gridster2/src/lib/tests/gridsterDraggable.spec.ts; npm run test-lib -- --watch=false; npm run build-lib.